### PR TITLE
:sparkles: Harden example CI and keep usage versions in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
+
+# Update policy
+# - The shipped Python package (pip) and GitHub Actions are updated daily,
+#   including major versions, so the action itself stays current and secure.
+# - The language examples (npm / bundler / gomod / cargo) are demos. They are
+#   updated weekly and **major-version bumps are ignored**, because a major bump
+#   can raise a dependency's required language runtime above what the example
+#   test matrix covers (e.g. parallel 1.x -> 2.1.0 requiring Ruby >= 3.3; see
+#   issues #482 / #484). Bump example majors intentionally alongside a matrix
+#   review instead of automatically.
 updates:
-  # Python dependencies
+  # Python dependencies (shipped package)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -11,48 +21,60 @@ updates:
           - "*"
     open-pull-requests-limit: 10
 
-  # Node.js dependencies
+  # Node.js dependencies (example)
   - package-ecosystem: "npm"
     directory: "/examples/nodejs"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
 
-  # Ruby dependencies
+  # Ruby dependencies (example)
   - package-ecosystem: "bundler"
     directory: "/examples/ruby"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
 
-  # Go dependencies
+  # Go dependencies (example)
   - package-ecosystem: "gomod"
     directory: "/examples/go"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
 
-  # Rust dependencies
+  # Rust dependencies (example)
   - package-ecosystem: "cargo"
     directory: "/examples/rust"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
 
   # GitHub Actions

--- a/.github/workflows/dependabot_prch.yml
+++ b/.github/workflows/dependabot_prch.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: tests/matrix_static.json
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/cicd_matrix.json
       - name: Configure Git Credentials

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: examples/go/go_project_matrix.json
 
@@ -138,9 +138,9 @@ jobs:
         id: go_test
         working-directory: ./examples/go
         shell: bash
-        run: |
-          output="$(go test -v ./...)"
-          echo "${output}"
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
+        run: go test -v ./...
 
   update_badge:
     needs: run_tests

--- a/.github/workflows/nodejs_test.yml
+++ b/.github/workflows/nodejs_test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: examples/nodejs/nodejs_project_matrix.json
 
@@ -126,9 +126,9 @@ jobs:
         id: npm_test
         working-directory: ./examples/nodejs
         shell: bash
-        run: |
-          output="$(npm test)"
-          echo "${output}"
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
+        run: npm test
 
   update_badge:
     needs: run_tests

--- a/.github/workflows/prch_test_matrix_json.yml
+++ b/.github/workflows/prch_test_matrix_json.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: tests/python_project_matrix.json
 

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: tests/python_project_matrix.json
 

--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: examples/ruby/ruby_project_matrix.json
 
@@ -126,10 +126,11 @@ jobs:
         id: ruby_test
         working-directory: ./examples/ruby
         shell: bash
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
         run: |
           bundle install
-          output="$(bundle exec rake test)"
-          echo "${output}"
+          bundle exec rake test
 
   update_badge:
     needs: run_tests

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: examples/rust/rust_project_matrix.json
 
@@ -134,9 +134,9 @@ jobs:
         id: rust_test
         working-directory: ./examples/rust
         shell: bash
-        run: |
-          output="$(cargo test --verbose)"
-          echo "${output}"
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
+        run: cargo test --verbose
 
       # Optional: Add code format check
       - name: Check formatting

--- a/.github/workflows/update-version-and-release.yml
+++ b/.github/workflows/update-version-and-release.yml
@@ -6,10 +6,11 @@ name: Version Update and Release
 # 2. Environment Setup (Ubuntu, uv)
 # 3. Retrieve the current version
 # 4. Update to the new version (patch, minor, or major)
-# 5. Commit and push the changes
-# 6. Create and push a new tag
-# 7. Generate the changelog
-# 8. Create a GitHub release
+# 5. Sync `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` references in docs/examples
+# 6. Commit and push the changes
+# 7. Create and push a new tag
+# 8. Generate the changelog
+# 9. Create a GitHub release
 
 on:
   workflow_dispatch:
@@ -48,9 +49,22 @@ jobs:
         run: |
           uv version --bump ${{ github.event.inputs.update_type }} --no-sync
           echo "new_version=$(uv version --short)" >> "$GITHUB_OUTPUT"
+      - name: Sync action version references in docs and examples
+        # Keep every `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` reference across
+        # README, docs and example workflows pinned to the version being released,
+        # so usage examples never lag behind the latest tag.
+        run: |
+          new_version="${{ steps.update_version.outputs.new_version }}"
+          mapfile -t files < <(grep -rlE "7rikazhexde/json2vars-setter@v[0-9]+\.[0-9]+\.[0-9]+" --include="*.md" --include="*.yml" .)
+          if [ "${#files[@]}" -gt 0 ]; then
+            sed -E -i "s#(7rikazhexde/json2vars-setter@v)[0-9]+\.[0-9]+\.[0-9]+#\1${new_version}#g" "${files[@]}"
+            printf 'Updated action version reference in:\n%s\n' "$(printf '  %s\n' "${files[@]}")"
+          else
+            echo "No action version references found to update."
+          fi
       - name: Commit and push if changed
         run: |
-          git add pyproject.toml uv.lock
+          git add pyproject.toml uv.lock README.md docs .github
           git commit -m ":wrench:Bump version to ${{ steps.update_version.outputs.new_version }}" || echo "No changes to commit"
           git push
       - name: Create and push new tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,10 @@ A pluggable architecture for fetching language versions from GitHub:
 - **Test coverage**: Minimum 95%, goal 100%. Branch coverage is disabled in config due to testmon compatibility
 - **Testing framework**: pytest with pytest-mock, pytest-cov, pytest-xdist
 
+## Versioning Rule
+
+When the action version is bumped, **all usage examples must be pinned to the new version**. Every `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` reference across `README.md`, `docs/**`, and the example workflows in `.github/workflows/**` must point to the version being released — usage examples must never lag behind the latest tag. The release workflow (`.github/workflows/update-version-and-release.yml`) automates this via its "Sync action version references" step; keep that step in sync if reference locations change, and apply the same rule for any manual version bump.
+
 ## Key File Locations
 
 - Matrix JSON: `.github/json2vars-setter/matrix.json`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
 

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -47,7 +47,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
 
@@ -127,7 +127,7 @@ jobs:
 
       - name: Set variables with dynamic update
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           update-matrix: 'true'
@@ -176,7 +176,7 @@ jobs:
 
       - name: Set variables with cached versions
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           use-cache: 'true'
@@ -209,7 +209,7 @@ jobs:
 
       - name: Set variables from custom JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/python_project_matrix.json
 
@@ -256,7 +256,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
 
@@ -316,7 +316,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Update matrix.json
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           update-matrix: 'true'

--- a/docs/examples/ci-cd.md
+++ b/docs/examples/ci-cd.md
@@ -30,7 +30,7 @@ jobs:
 
       - name: Update matrix configuration
         id: update_matrix
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           update-matrix: 'true'
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
 
@@ -107,7 +107,7 @@ jobs:
 
       # Apply matrix updates again since they were not committed yet
       - name: Update matrix configuration
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           update-matrix: 'true'
@@ -190,14 +190,14 @@ jobs:
       - name: Set variables for production
         id: json2vars_prod
         if: steps.environment.outputs.env == 'production'
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/production_matrix.json
 
       - name: Set variables for development
         id: json2vars_dev
         if: steps.environment.outputs.env == 'development'
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/development_matrix.json
           update-matrix: 'true'
@@ -298,7 +298,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Update version cache
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           use-cache: 'true'
@@ -331,7 +331,7 @@ jobs:
 
       - name: Set variables from cache
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           use-cache: 'true'
@@ -402,7 +402,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update version cache
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           use-cache: 'true'
@@ -412,7 +412,7 @@ jobs:
           keep-existing: 'true'
 
       - name: Update dynamic versions
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/latest_matrix.json
           update-matrix: 'true'
@@ -481,7 +481,7 @@ jobs:
 
       - name: Set variables for Project A
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: project-a/.github/matrix.json
           use-cache: 'true'
@@ -525,7 +525,7 @@ jobs:
 
       - name: Set variables for Project B
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: project-b/.github/matrix.json
           use-cache: 'true'

--- a/docs/examples/troubleshooting.md
+++ b/docs/examples/troubleshooting.md
@@ -17,7 +17,7 @@ This guide helps you diagnose and resolve common issues when using the JSON to V
 ```yaml
 - name: Set variables with authentication
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: 'true'
@@ -38,12 +38,12 @@ This guide helps you diagnose and resolve common issues when using the JSON to V
           ```yaml
           # Incorrect - missing id
           - name: Set variables from JSON
-            uses: 7rikazhexde/json2vars-setter@v1.0.2
+            uses: 7rikazhexde/json2vars-setter@v1.0.4
 
           # Correct
           - name: Set variables from JSON
             id: json2vars  # This is required to reference outputs
-            uses: 7rikazhexde/json2vars-setter@v1.0.2
+            uses: 7rikazhexde/json2vars-setter@v1.0.4
           ```
 
     2. **JSON structure issue**:
@@ -112,7 +112,7 @@ This guide helps you diagnose and resolve common issues when using the JSON to V
 
         ```yaml
         - name: Force cache update
-          uses: 7rikazhexde/json2vars-setter@v1.0.2
+          uses: 7rikazhexde/json2vars-setter@v1.0.4
           with:
             json-file: .github/json2vars-setter/sample/matrix.json
             use-cache: 'true'
@@ -149,7 +149,7 @@ This guide helps you diagnose and resolve common issues when using the JSON to V
     ```yaml
     # Incorrect - conflicting strategies
     - name: Set variables
-      uses: 7rikazhexde/json2vars-setter@v1.0.2
+      uses: 7rikazhexde/json2vars-setter@v1.0.4
       with:
         json-file: .github/json2vars-setter/sample/matrix.json
         update-matrix: 'true'
@@ -157,7 +157,7 @@ This guide helps you diagnose and resolve common issues when using the JSON to V
 
     # Correct - choose one strategy
     - name: Set variables with dynamic update
-      uses: 7rikazhexde/json2vars-setter@v1.0.2
+      uses: 7rikazhexde/json2vars-setter@v1.0.4
       with:
         json-file: .github/json2vars-setter/sample/matrix.json
         update-matrix: 'true'
@@ -180,7 +180,7 @@ Or use the built-in debug output:
 ```yaml
 - name: Set variables with debug
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: 'true'
@@ -286,7 +286,7 @@ Choose a JSON file dynamically based on context:
 
 - name: Set variables from dynamic path
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: ${{ steps.config_file.outputs.file }}
 ```
@@ -309,7 +309,7 @@ Select update strategy based on specific conditions:
 
 - name: Set variables
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: ${{ steps.strategy.outputs.update }}
@@ -329,7 +329,7 @@ Use GitHub authentication to increase API rate limits:
 
 - name: Set variables with authentication
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: 'true'
@@ -345,7 +345,7 @@ Optimize your workflow to reduce API calls:
 
     ```yaml
     - name: Set variables with caching
-      uses: 7rikazhexde/json2vars-setter@v1.0.2
+      uses: 7rikazhexde/json2vars-setter@v1.0.4
       with:
         json-file: .github/json2vars-setter/sample/matrix.json
         use-cache: 'true'
@@ -356,7 +356,7 @@ Optimize your workflow to reduce API calls:
 
     ```yaml
     - name: Set variables from cache
-      uses: 7rikazhexde/json2vars-setter@v1.0.2
+      uses: 7rikazhexde/json2vars-setter@v1.0.4
       with:
         json-file: .github/json2vars-setter/sample/matrix.json
         use-cache: 'true'
@@ -377,7 +377,7 @@ Keep a comprehensive version history while minimizing API usage:
 
 ```yaml
 - name: Update cache incrementally
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     use-cache: 'true'

--- a/docs/features/dynamic-update.md
+++ b/docs/features/dynamic-update.md
@@ -66,7 +66,7 @@ One of the key advantages is the ability to specify different update strategies 
 ```yaml
 - name: Set variables from dynamically updated JSON
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: 'true'
@@ -82,7 +82,7 @@ Test your update strategies without modifying your JSON file using the dry-run o
 ```yaml
 - name: Test dynamic update without changing files
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: 'true'
@@ -115,7 +115,7 @@ jobs:
 
       - name: Set variables with dynamic update
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           update-matrix: 'true'
@@ -135,7 +135,7 @@ You can mix and match update strategies for different languages:
 ```yaml
 - name: Set variables with mixed update strategies
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: 'true'
@@ -163,7 +163,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Update matrix.json
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
           update-matrix: 'true'

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -120,7 +120,7 @@ The flexibility of json2vars-setter allows you to choose the components that bes
 ```yaml
 - name: Set variables from JSON
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
 ```
@@ -129,7 +129,7 @@ The flexibility of json2vars-setter allows you to choose the components that bes
 
 ```yaml
 - name: Update matrix with latest versions
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: 'true'
@@ -141,7 +141,7 @@ The flexibility of json2vars-setter allows you to choose the components that bes
 
 ```yaml
 - name: Update using cached version info
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     use-cache: 'true'

--- a/docs/features/json-to-variables.md
+++ b/docs/features/json-to-variables.md
@@ -97,7 +97,7 @@ The parser generates these outputs:
 ```yaml
 - name: Set variables from JSON
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
 ```

--- a/docs/features/version-caching.md
+++ b/docs/features/version-caching.md
@@ -204,7 +204,7 @@ In GitHub Actions, these options are mapped to action inputs:
 ```yaml
 - name: Set variables with cached versions
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     use-cache: 'true'
@@ -282,7 +282,7 @@ When fetching version information from GitHub APIs, you might encounter rate lim
     ```yaml
     - name: Set variables with cached versions
       id: json2vars
-      uses: 7rikazhexde/json2vars-setter@v1.0.2
+      uses: 7rikazhexde/json2vars-setter@v1.0.4
       with:
         json-file: .github/json2vars-setter/sample/matrix.json
         use-cache: 'true'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.0.2
+        uses: 7rikazhexde/json2vars-setter@v1.0.4
         with:
           json-file: .github/json2vars-setter/sample/matrix.json
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -86,7 +86,7 @@ Some input parameters have relationships or constraints:
 ```yaml
 - name: Set variables with dynamic update
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     update-matrix: 'true'
@@ -99,7 +99,7 @@ Some input parameters have relationships or constraints:
 ```yaml
 - name: Set variables with caching
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
     use-cache: 'true'
@@ -113,7 +113,7 @@ Some input parameters have relationships or constraints:
 ```yaml
 - name: Set variables from static JSON
   id: json2vars
-  uses: 7rikazhexde/json2vars-setter@v1.0.2
+  uses: 7rikazhexde/json2vars-setter@v1.0.4
   with:
     json-file: .github/json2vars-setter/sample/matrix.json
 ```


### PR DESCRIPTION
## Summary

Follow-up to #483 addressing two requests:
1. Prevent recurrence of dependency/runtime mismatches in the example CI (#484)
2. Keep action usage examples pinned to the latest released version, as a versioning rule

## Changes

### CI log visibility (go / nodejs / ruby / rust test workflows)
Run example tests **directly** instead of `output="$(cmd)"; echo "$output"`. Under `set -e -o pipefail` a failing test aborted **before** the echo, hiding the failure output (this cost an extra CI round in #483). `output` was never consumed downstream.

### Dependabot policy (`.github/dependabot.yml`)
Example ecosystems (`npm` / `bundler` / `gomod` / `cargo`) are now **weekly** and **ignore major-version bumps**, because a major bump can raise a dependency's required language runtime above the example test matrix (e.g. `parallel 1.x → 2.1.0` needing Ruby >= 3.3). The shipped `pip` package and `github-actions` keep daily updates including majors.

### Usage version sync + rule
- Update every `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` reference across README, docs and example workflows from `v1.0.2` → **`v1.0.4`** (they had lagged since 1.0.2).
- Automate it: new **Sync action version references** step in `update-version-and-release.yml` rewrites all references to the version being released and includes them in the bump commit.
- Document the rule in `CLAUDE.md`.

## Note on "a uv-like tool"
A Ruby equivalent of `uv` would **not** have prevented #482 — Ruby already has Bundler + `Gemfile.lock` and the lock worked. The root cause was the gap between the example's supported runtime range and a dependency's required runtime range, which these Dependabot/CI guardrails address directly.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)