### PR TITLE
:bug: Make cleanup-pr-caches tolerate individual cache delete failures

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -34,11 +34,17 @@ jobs:
           gh extension install actions/gh-actions-cache
           echo "Fetching caches for ${BRANCH}..."
           deleted=0
+          # Deletions are best-effort: a cache can disappear between list and
+          # delete (concurrent runs, GitHub eviction), so a single failure must
+          # not abort the whole cleanup. Count only successful deletions.
           while IFS= read -r key; do
             [ -z "$key" ] && continue
             echo "Deleting cache: ${key}"
-            gh actions-cache delete "$key" -R "$GH_REPO" -B "$BRANCH" --confirm
-            deleted=$((deleted + 1))
+            if gh actions-cache delete "$key" -R "$GH_REPO" -B "$BRANCH" --confirm; then
+              deleted=$((deleted + 1))
+            else
+              echo "  skip (could not delete; already gone?): ${key}"
+            fi
           done < <(gh actions-cache list -R "$GH_REPO" -B "$BRANCH" --limit 100 | cut -f 1)
           echo "Done. Deleted ${deleted} cache(s) for ${BRANCH}."
 


### PR DESCRIPTION
## Summary

Fixes `cleanup-pr-caches` (in `.github/workflows/cleanup-caches.yml`) failing the whole job when a single `gh actions-cache delete` errors. Observed on the close of PR #486:

```
Error: Cache with input key '...' does not exist
##[error]Process completed with exit code 1
```

## Root cause

The step runs under `bash -e`. A cache can disappear between `gh actions-cache list` and `delete` (concurrent runs, GitHub eviction), so `delete` reports *does not exist* and exits non-zero, aborting the entire cleanup. Cache cleanup is best-effort (GitHub's own documented example uses `set +e` for this reason).

## Fix

Wrap each deletion in an `if`: log and skip failures, count only successful deletions. One missing cache no longer fails the job.

Note: this job only runs on the `pull_request: closed` event, so it is exercised on the next PR close rather than on this PR's checks. YAML and `bash -n` validated locally.

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)