### PR TITLE
:recycle: Reorganize json2vars_setter into features/ subpackage + shared version registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,10 @@ just test-cov-verbose
 just
 
 # Run a single test file
-uv run pytest tests/test_json_to_github_output.py
+uv run pytest tests/features/test_github_output.py
 
 # Run a single test by name
-uv run pytest tests/test_cache_version_info.py -k "test_function_name"
+uv run pytest tests/features/test_version_cache.py -k "test_function_name"
 
 # Lint (ruff)
 uv run ruff check json2vars_setter
@@ -46,20 +46,21 @@ uv run json2vars --help
 
 ## Architecture
 
-### Three Core Modules
+### Three Feature Modules (`json2vars_setter/features/`)
 
-The action has three processing stages with a priority chain: **dynamic update > cache version > JSON parse**.
+The action has three processing stages with a priority chain: **dynamic update > cache version > JSON parse**. Each stage is a module under `json2vars_setter/features/` exposing a `build_parser()` + `main(argv=None)` pair (so it runs both via `python -m` and in-process from the CLI):
 
-1. **`json_to_github_output.py`** — Always runs. Recursively flattens a JSON file into `GITHUB_OUTPUT` key-value pairs. Nested keys are joined with underscores and uppercased (e.g., `versions.python` → `VERSIONS_PYTHON`). Lists are serialized as JSON strings.
+1. **`features/github_output.py`** — Always runs. Recursively flattens a JSON file into `GITHUB_OUTPUT` key-value pairs. Nested keys are joined with underscores and uppercased (e.g., `versions.python` → `VERSIONS_PYTHON`). Lists are serialized as JSON strings.
 
-2. **`update_matrix_dynamic.py`** — Optionally runs (highest priority). Fetches latest/stable language versions from GitHub APIs and updates the matrix JSON in-place before parsing. Uses `VersionStrategy` (STABLE, LATEST, BOTH) per language.
+2. **`features/matrix_update.py`** — Optionally runs (highest priority). Fetches latest/stable language versions from GitHub APIs and updates the matrix JSON in-place before parsing. Uses `VersionStrategy` (STABLE, LATEST, BOTH) per language.
 
-3. **`cache_version_info.py`** — Optionally runs (medium priority, only if dynamic update is off). Manages a TTL-based version cache file, supports incremental updates, and generates matrix templates from cached data.
+3. **`features/version_cache.py`** — Optionally runs (medium priority, only if dynamic update is off). Manages a TTL-based version cache file, supports incremental updates, and generates matrix templates from cached data.
 
 ### Version Fetcher System (`json2vars_setter/version/`)
 
 A pluggable architecture for fetching language versions from GitHub:
 
+- **`version/registry.py`** — `get_version_fetcher(language)` and the `LANGUAGE_FETCHERS` map: the single source of truth pairing each language with its fetcher (shared by the matrix-update and version-cache features)
 - **`version/core/base.py`** — `BaseVersionFetcher` abstract class handles GitHub API pagination, authentication (via `GITHUB_TOKEN`), and defines the interface (`_is_stable_tag()`, `_parse_version_from_tag()`)
 - **`version/core/exceptions.py`** — Exception hierarchy: `VersionFetchError` → `GitHubAPIError`, `ParseError`, `ValidationError`
 - **`version/core/utils.py`** — Shared data classes (`VersionInfo`, `ReleaseInfo`) and helpers
@@ -67,9 +68,9 @@ A pluggable architecture for fetching language versions from GitHub:
 
 ### Entry Points
 
-- **GitHub Action**: `action.yml` defines the composite action with inputs/outputs
-- **CLI**: `json2vars_setter/cli.py` — Typer app exposed as `json2vars` via `[project.scripts]`
-- **Direct module execution**: `python -m json2vars_setter.<module>`
+- **GitHub Action**: `action.yml` defines the composite action with inputs/outputs; its steps invoke `python -m json2vars_setter.features.<module>`
+- **CLI**: `json2vars_setter/cli.py` — Typer app exposed as `json2vars` via `[project.scripts]`; commands call each feature's `main()` **in-process** (no subprocess)
+- **Direct module execution**: `python -m json2vars_setter.features.<module>`
 
 ## Code Conventions
 

--- a/action.yml
+++ b/action.yml
@@ -202,7 +202,7 @@ runs:
 
         # Execute update script using uv with isolated environment
         cd ${{ github.action_path }}
-        uv run --no-sync python -m json2vars_setter.update_matrix_dynamic "${ARGS[@]}"
+        uv run --no-sync python -m json2vars_setter.features.matrix_update "${ARGS[@]}"
 
     # Cache version info update (medium priority)
     - name: Update using cache version info if requested
@@ -268,13 +268,13 @@ runs:
         ARGS+=("--verbose")
 
         # Output the full command for debugging
-        echo "Running command: uv run python -m json2vars_setter.cache_version_info with files:"
+        echo "Running command: uv run python -m json2vars_setter.features.version_cache with files:"
         echo "  Cache file: ${CACHE_FILE}"
         echo "  Template file: ${JSON_FILE}"
 
         # Execute cache version info script using uv with isolated environment
         cd ${{ github.action_path }}
-        uv run --no-sync python -m json2vars_setter.cache_version_info "${ARGS[@]}"
+        uv run --no-sync python -m json2vars_setter.features.version_cache "${ARGS[@]}"
 
     # JSON parsing (always executed)
     - name: Parse JSON and set outputs
@@ -293,7 +293,7 @@ runs:
 
         # Execute script from action directory with isolated environment
         cd ${{ github.action_path }}
-        uv run --no-sync python -m json2vars_setter.json_to_github_output "${JSON_ABSOLUTE_PATH}"
+        uv run --no-sync python -m json2vars_setter.features.github_output "${JSON_ABSOLUTE_PATH}"
       env:
         GITHUB_OUTPUT: $GITHUB_OUTPUT
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,9 +18,9 @@ Thank you for your interest in contributing to my JSON to Variables Setter actio
   - [Coding Guidelines](#coding-guidelines)
   - [Documentation](#documentation)
   - [Core Components Development](#core-components-development)
-    - [JSON to GitHub Output Parser (`json_to_github_output.py`)](#json-to-github-output-parser-json_to_github_outputpy)
-    - [Dynamic Matrix Updater (`update_matrix_dynamic.py`)](#dynamic-matrix-updater-update_matrix_dynamicpy)
-    - [Version Cache Manager (`cache_version_info.py`)](#version-cache-manager-cache_version_infopy)
+    - [JSON to GitHub Output Parser (`github_output.py`)](#json-to-github-output-parser-github_outputpy)
+    - [Dynamic Matrix Updater (`matrix_update.py`)](#dynamic-matrix-updater-matrix_updatepy)
+    - [Version Cache Manager (`version_cache.py`)](#version-cache-manager-version_cachepy)
   - [Release Process](#release-process)
   - [Feedback](#feedback)
 
@@ -79,10 +79,15 @@ json2vars-setter/
 ├── .github/           # GitHub specific files (workflows, templates)
 ├── json2vars_setter/  # Core Python module
 │   ├── __init__.py
-│   ├── json_to_github_output.py  # JSON parser component
-│   ├── update_matrix_dynamic.py  # Dynamic update component
-│   ├── cache_version_info.py     # Version caching component
-│   └── version/       # Version fetching modules
+│   ├── cli.py            # Typer CLI (json2vars), runs features in-process
+│   ├── features/         # The three action stages
+│   │   ├── github_output.py  # JSON parser component (always runs)
+│   │   ├── matrix_update.py   # Dynamic update component
+│   │   └── version_cache.py   # Version caching component
+│   └── version/          # Version fetching modules
+│       ├── registry.py   # get_version_fetcher() (single source of truth)
+│       ├── core/         # Base fetcher, exceptions, utils
+│       └── fetchers/     # Per-language fetchers
 ├── tests/             # Test files
 ├── docs/              # Documentation files
 ├── action.yml         # Action definition
@@ -248,19 +253,19 @@ For MkDocs documentation:
 
 When working on my core components, consider the following guidelines:
 
-### JSON to GitHub Output Parser (`json_to_github_output.py`)
+### JSON to GitHub Output Parser (`github_output.py`)
 
 - Maintain backward compatibility with existing JSON structures
 - Ensure proper error handling for malformed JSON
 - Optimize for performance with large JSON files
 
-### Dynamic Matrix Updater (`update_matrix_dynamic.py`)
+### Dynamic Matrix Updater (`matrix_update.py`)
 
 - Keep the code DRY (Don't Repeat Yourself) when implementing different language fetchers
 - Handle API rate limits gracefully
 - Implement proper error handling and logging
 
-### Version Cache Manager (`cache_version_info.py`)
+### Version Cache Manager (`version_cache.py`)
 
 - Ensure thread-safety for file operations
 - Optimize disk I/O and API calls

--- a/docs/examples/troubleshooting.md
+++ b/docs/examples/troubleshooting.md
@@ -172,7 +172,7 @@ Add the `--verbose` flag to see detailed logs:
 ```yaml
 - name: Debug cache version info
   run: |
-    python ${{ github.action_path }}/json2vars_setter/cache_version_info.py --verbose
+    python ${{ github.action_path }}/json2vars_setter/features/version_cache.py --verbose
 ```
 
 Or use the built-in debug output:
@@ -192,11 +192,11 @@ Or use the built-in debug output:
 You can test the scripts locally before using them in GitHub Actions:
 
 ```bash
-# Test cache_version_info.py
-python path/to/cache_version_info.py --template-only --verbose
+# Test version_cache.py
+python path/to/version_cache.py --template-only --verbose
 
-# Test update_matrix_dynamic.py
-python path/to/update_matrix_dynamic.py --json-file ./matrix.json --all stable --dry-run
+# Test matrix_update.py
+python path/to/matrix_update.py --json-file ./matrix.json --all stable --dry-run
 ```
 
 ### Inspect Generated Files

--- a/docs/features/dynamic-update.md
+++ b/docs/features/dynamic-update.md
@@ -1,6 +1,6 @@
 # Dynamic Matrix Update
 
-The Dynamic Matrix Updater (`update_matrix_dynamic.py`) automatically updates your matrix configuration with the latest or stable language versions from official sources.
+The Dynamic Matrix Updater (`matrix_update.py`) automatically updates your matrix configuration with the latest or stable language versions from official sources.
 
 ## Overview
 
@@ -11,7 +11,7 @@ graph TD
     Start[json2vars-setter Action] -->|Input Parameters| Condition{update-matrix?}
 
     %% False path - direct JSON parsing
-    Condition -->|false| G[json_to_github_output.py]
+    Condition -->|false| G[github_output.py]
 
     %% True path - update then parse
     Condition -->|true| Step1[Read JSON File<br>#40;If not specified, read in matrix.json#41;]
@@ -203,15 +203,15 @@ When you set `update-matrix: 'true'`, the action performs these steps internally
 3. **Apply Update Strategy**: Versions are filtered based on the specified strategy for each language
 4. **Create a Backup**: Before making changes, a backup of the original file is created (unless in dry-run mode)
 5. **Update the Matrix**: The JSON file is updated with the new version information
-6. **Parse JSON**: The updated JSON file is processed by json_to_github_output.py
+6. **Parse JSON**: The updated JSON file is processed by github_output.py
 7. **Set Outputs**: The values from the JSON file are set as GitHub Actions outputs
 
 ```mermaid
 sequenceDiagram
     participant Workflow as GitHub Workflow
     participant Action as json2vars-setter
-    participant Updater as update_matrix_dynamic.py
-    participant Parser as json_to_github_output.py
+    participant Updater as matrix_update.py
+    participant Parser as github_output.py
     participant API as Language APIs
     participant File as matrix.json
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -33,7 +33,7 @@ graph TD
     class E api
 ```
 
-### 1. JSON to Variables Parser (`json_to_github_output.py`)
+### 1. JSON to Variables Parser (`github_output.py`)
 
 The core component of the action. It reads a JSON configuration file and converts its contents into GitHub Actions output variables that can be used in your workflows.
 
@@ -46,7 +46,7 @@ The core component of the action. It reads a JSON configuration file and convert
 
 [Learn more about JSON to Variables](json-to-variables.md)
 
-### 2. Dynamic Matrix Updater (`update_matrix_dynamic.py`)
+### 2. Dynamic Matrix Updater (`matrix_update.py`)
 
 Automatically updates your matrix configuration with the latest or stable language versions from official sources.
 
@@ -59,7 +59,7 @@ Automatically updates your matrix configuration with the latest or stable langua
 
 [Learn more about Dynamic Updates](dynamic-update.md)
 
-### 3. Version Cache Manager (`cache_version_info.py`)
+### 3. Version Cache Manager (`version_cache.py`)
 
 Manages version information cache to optimize API usage and workflow performance.
 
@@ -79,12 +79,12 @@ The components of json2vars-setter can be used independently or in combination:
 
 ```mermaid
 graph LR
-    A[Manual Configuration] -->|Option 1| D[json_to_github_output.py]
+    A[Manual Configuration] -->|Option 1| D[github_output.py]
 
-    B[Dynamic Update] -->|Option 2| C[update_matrix_dynamic.py]
+    B[Dynamic Update] -->|Option 2| C[matrix_update.py]
     C -->|Updates| D
 
-    E[Cached Versions] -->|Option 3| F[cache_version_info.py]
+    E[Cached Versions] -->|Option 3| F[version_cache.py]
     F -->|Generates| D
 
     D -->|Sets| G[GitHub Outputs]

--- a/docs/features/json-to-variables.md
+++ b/docs/features/json-to-variables.md
@@ -1,6 +1,6 @@
 # JSON to Variables
 
-The JSON to Variables Parser (`json_to_github_output.py`) is the core component of the json2vars-setter action. It reads a JSON configuration file and sets its values as output variables in GitHub Actions workflows.
+The JSON to Variables Parser (`github_output.py`) is the core component of the json2vars-setter action. It reads a JSON configuration file and sets its values as output variables in GitHub Actions workflows.
 
 ## Overview
 
@@ -8,7 +8,7 @@ This component serves as the foundation of the entire action, transforming stati
 
 ```mermaid
 graph LR
-    A[JSON File] -->|Read| B[json_to_github_output.py]
+    A[JSON File] -->|Read| B[github_output.py]
     B -->|Parse| C[Extract Values]
     C -->|Format| D[Set GitHub Outputs]
     D -->|Available in| E[Workflow Steps]
@@ -207,7 +207,7 @@ For direct access to specific array elements:
 
 ## Technical Details
 
-The `json_to_github_output.py` script:
+The `github_output.py` script:
 
 1. Accepts a JSON file path as input
 2. Uses Python's `json` module to parse the file

--- a/docs/features/version-caching.md
+++ b/docs/features/version-caching.md
@@ -61,12 +61,12 @@ graph TD
 
 ### Tips
 
-!!! tip "[*1]: Specify language"
+!!! tip "\[*1\]: Specify language"
 
     - Specify languages separated by **spaces**; if `all` is specified, all target languages are retrieved.
     - Target languages: `python`, `nodejs`, `ruby`, `go`, `rust`
 
-!!! tip "[*2]: specify a path"
+!!! tip "\[*2\]: specify a path"
 
     - If the file does not exist in the path, an error will occur, so please create it beforehand.
 

--- a/docs/features/version-caching.md
+++ b/docs/features/version-caching.md
@@ -1,6 +1,6 @@
 # Version Caching
 
-The Version Cache Manager (`cache_version_info.py`) manages version information cache to optimize API usage and workflow performance.
+The Version Cache Manager (`version_cache.py`) manages version information cache to optimize API usage and workflow performance.
 
 ## Overview
 
@@ -11,9 +11,9 @@ This component reduces external API calls by caching version information, making
 ```mermaid
 graph TD
     Start[json2vars-setter Action] -->|Input Parameters| GHACondition{use-cache?}
-    GHACondition --> |true| MainPurpose1[cache_version_info.py]
+    GHACondition --> |true| MainPurpose1[version_cache.py]
 
-    MainPurpose1[cache_version_info.py] --> MainPurpose2{Main Functions}
+    MainPurpose1[version_cache.py] --> MainPurpose2{Main Functions}
 
     MainPurpose2 -->|Create Template JSON| TemplateCreation[Template Creation]
     MainPurpose2 -->|Cache Version Info| CacheCreation[Cache Creation]
@@ -104,25 +104,25 @@ graph TD
 #### Generate template from existing cache without API calls
 
 ```bash
-python json2vars_setter/cache_version_info.py --template-only
+python json2vars_setter/features/version_cache.py --template-only
 ```
 
 #### Update specific languages only (maintain other language information)
 
 ```bash
-python json2vars_setter/cache_version_info.py --template-only --languages python --keep-existing
+python json2vars_setter/features/version_cache.py --template-only --languages python --keep-existing
 ```
 
 #### Fetch latest information from API and create template
 
 ```bash
-python json2vars_setter/cache_version_info.py
+python json2vars_setter/features/version_cache.py
 ```
 
 #### Cache many versions but limit output to most recent ones
 
 ```bash
-python json2vars_setter/cache_version_info.py --count 10 --output-count 3
+python json2vars_setter/features/version_cache.py --count 10 --output-count 3
 ```
 
 ### Cache Creation and Management
@@ -130,19 +130,19 @@ python json2vars_setter/cache_version_info.py --count 10 --output-count 3
 #### Force fetch latest information
 
 ```bash
-python json2vars_setter/cache_version_info.py --force
+python json2vars_setter/features/version_cache.py --force
 ```
 
 #### Update only after a certain period (e.g., 7 days)
 
 ```bash
-python json2vars_setter/cache_version_info.py --max-age 7
+python json2vars_setter/features/version_cache.py --max-age 7
 ```
 
 #### Accumulate version history (add new versions)
 
 ```bash
-python json2vars_setter/cache_version_info.py --incremental --count 30
+python json2vars_setter/features/version_cache.py --incremental --count 30
 ```
 
 ## Advanced Usage
@@ -154,25 +154,25 @@ python json2vars_setter/cache_version_info.py --incremental --count 30
 ##### Write support language version (python,nodejs,ruby,go,rust)
 
 ```bash
-python json2vars_setter/cache_version_info.py --template-file ./your_project_matrix.json
+python json2vars_setter/features/version_cache.py --template-file ./your_project_matrix.json
 ```
 
 ##### Write specified support language version (python,nodejs)
 
 ```bash
-python json2vars_setter/cache_version_info.py --lang python nodejs --template-file ./your_project_matrix.json
+python json2vars_setter/features/version_cache.py --lang python nodejs --template-file ./your_project_matrix.json
 ```
 
 ##### Write specified support language version (python)
 
 ```bash
-python json2vars_setter/cache_version_info.py --lang python --template-file ./your_python_matrix.json
+python json2vars_setter/features/version_cache.py --lang python --template-file ./your_python_matrix.json
 ```
 
 #### Maintain existing file structure
 
 ```bash
-python json2vars_setter/cache_version_info.py --existing-template ./project_matrix.json --template-file ./updated_matrix.json
+python json2vars_setter/features/version_cache.py --existing-template ./project_matrix.json --template-file ./updated_matrix.json
 ```
 
 ### Version Control Flexibility
@@ -180,7 +180,7 @@ python json2vars_setter/cache_version_info.py --existing-template ./project_matr
 #### Cache complete history but test only latest versions
 
 ```bash
-python json2vars_setter/cache_version_info.py --count 15 --output-count 3
+python json2vars_setter/features/version_cache.py --count 15 --output-count 3
 ```
 
 ### CI/CD Integration
@@ -188,13 +188,13 @@ python json2vars_setter/cache_version_info.py --count 15 --output-count 3
 #### Scheduled job (cache update only)
 
 ```bash
-python json2vars_setter/cache_version_info.py --max-age 7 --cache-only
+python json2vars_setter/features/version_cache.py --max-age 7 --cache-only
 ```
 
 #### Pre-build processing (template generation only)
 
 ```bash
-python json2vars_setter/cache_version_info.py --template-only
+python json2vars_setter/features/version_cache.py --template-only
 ```
 
 ## GitHub Actions Integration
@@ -230,15 +230,15 @@ When you set `use-cache: 'true'`, the action performs these steps internally:
 4. **Generate Template**: It creates or updates the matrix JSON file based on the cached data, respecting version limits
     - If `output-count` is specified, only that many versions are included in the template
     - Otherwise, `cache-count` versions are included
-5. **Parse JSON**: The matrix JSON file is processed by json_to_github_output.py
+5. **Parse JSON**: The matrix JSON file is processed by github_output.py
 6. **Set Outputs**: The values from the JSON file are set as GitHub Actions outputs
 
 ```mermaid
 sequenceDiagram
     participant Workflow as GitHub Workflow
     participant Action as json2vars-setter
-    participant CacheMgr as cache_version_info.py
-    participant Parser as json_to_github_output.py
+    participant CacheMgr as version_cache.py
+    participant Parser as github_output.py
     participant API as Language APIs
     participant Cache as version_cache.json
     participant File as matrix.json

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,11 +101,11 @@ graph TD
     class E api
 ```
 
-1. **JSON to Variables Parser** (`json_to_github_output.py`): Core component that parses JSON and converts it to GitHub Actions outputs. Makes your configuration data accessible throughout your workflow.
+1. **JSON to Variables Parser** (`github_output.py`): Core component that parses JSON and converts it to GitHub Actions outputs. Makes your configuration data accessible throughout your workflow.
 
-2. **Dynamic Matrix Updater** (`update_matrix_dynamic.py`): Updates your matrix configuration with the latest or stable language versions. Ensures your CI/CD tests run against current language versions without manual updates.
+2. **Dynamic Matrix Updater** (`matrix_update.py`): Updates your matrix configuration with the latest or stable language versions. Ensures your CI/CD tests run against current language versions without manual updates.
 
-3. **Version Cache Manager** (`cache_version_info.py`): Manages cached version information to optimize API usage. Reduces external API calls by intelligently caching data, improving workflow performance and reliability.
+3. **Version Cache Manager** (`version_cache.py`): Manages cached version information to optimize API usage. Reduces external API calls by intelligently caching data, improving workflow performance and reliability.
 
 ## Learn More
 

--- a/json2vars_setter/cli.py
+++ b/json2vars_setter/cli.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """
 json2vars_setter CLI tool.
-Unified interface for calling existing scripts using Typer.
+Unified interface that runs the package features in-process via Typer.
 """
 
-import subprocess
-import sys
-from pathlib import Path
+from typing import Callable, List
 
 import typer
+
+from json2vars_setter.features import matrix_update, version_cache
 
 # Create application instance
 app = typer.Typer(
@@ -16,67 +16,51 @@ app = typer.Typer(
     help="json2vars_setter CLI: Manages multiple scripts within the project",
 )
 
+# Pass-through settings: forward every argument to the feature's own argparse
+# parser (including --help/-h, by disabling Typer's built-in help option).
+_PASSTHROUGH = {
+    "allow_extra_args": True,
+    "ignore_unknown_options": True,
+    "help_option_names": [],
+}
+
+
+def _run_feature(name: str, run: Callable[[List[str]], None], args: List[str]) -> None:
+    """Run a feature's ``main`` in-process, mapping failures to a Typer exit.
+
+    argparse raises ``SystemExit`` for ``--help`` (code 0) and usage errors
+    (non-zero); any other exception is surfaced as a CLI error.
+    """
+    try:
+        run(args)
+    except SystemExit as exc:
+        code = exc.code
+        if code is None or code == 0:
+            return
+        raise typer.Exit(code if isinstance(code, int) else 1)
+    except Exception as exc:  # noqa: BLE001 - surface any failure as a CLI error
+        typer.echo(f"Error: Failed to execute {name} ({exc})", err=True)
+        raise typer.Exit(1)
+
 
 @app.command(
     "cache-version",
-    help="cache_version_info.py: Caches version information of programming languages",
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    help="version_cache: Caches version information of programming languages",
+    context_settings=_PASSTHROUGH,
 )
-def cache_version(
-    ctx: typer.Context,
-    help: bool = typer.Option(False, "--help", "-h", is_flag=True, help="Show help"),
-) -> None:
-    """
-    Executes the cache_version_info.py script. All arguments are passed as is.
-    """
-    script_path = Path(__file__).parent / "cache_version_info.py"
-
-    # If the --help flag is specified, display the original script's help
-    if help:
-        args = ["--help"]
-    else:
-        args = ctx.args
-
-    try:
-        result = subprocess.run(
-            [sys.executable, str(script_path)] + args,
-            check=True,
-        )
-        sys.exit(result.returncode)
-    except subprocess.CalledProcessError as e:
-        typer.echo(f"Error: Failed to execute cache_version_info.py ({e})", err=True)
-        sys.exit(e.returncode)
+def cache_version(ctx: typer.Context) -> None:
+    """Run the version-cache feature. All arguments are passed through as-is."""
+    _run_feature("version_cache", version_cache.main, ctx.args)
 
 
 @app.command(
     "update-matrix",
-    help="update_matrix_dynamic.py: Dynamically updates matrix.json with the latest or stable versions",
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    help="matrix_update: Dynamically updates matrix.json with the latest or stable versions",
+    context_settings=_PASSTHROUGH,
 )
-def update_matrix(
-    ctx: typer.Context,
-    help: bool = typer.Option(False, "--help", "-h", is_flag=True, help="Show help"),
-) -> None:
-    """
-    Executes the update_matrix_dynamic.py script. All arguments are passed as is.
-    """
-    script_path = Path(__file__).parent / "update_matrix_dynamic.py"
-
-    # If the --help flag is specified, display the original script's help
-    if help:
-        args = ["--help"]
-    else:
-        args = ctx.args
-
-    try:
-        result = subprocess.run(
-            [sys.executable, str(script_path)] + args,
-            check=True,
-        )
-        sys.exit(result.returncode)
-    except subprocess.CalledProcessError as e:
-        typer.echo(f"Error: Failed to execute update_matrix_dynamic.py ({e})", err=True)
-        sys.exit(e.returncode)
+def update_matrix(ctx: typer.Context) -> None:
+    """Run the update-matrix feature. All arguments are passed through as-is."""
+    _run_feature("matrix_update", matrix_update.main, ctx.args)
 
 
 @app.command("usage", help="Displays available commands and their usage")

--- a/json2vars_setter/features/github_output.py
+++ b/json2vars_setter/features/github_output.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 
 def set_github_output(outputs: Dict[str, str], debug: bool) -> None:
@@ -71,10 +71,18 @@ def parse_json(data: Any, prefix: str = "", debug: bool = False) -> Dict[str, st
     return outputs
 
 
-if __name__ == "__main__":
+def main(argv: Optional[List[str]] = None) -> None:
+    """Read a JSON file and write its contents to GITHUB_OUTPUT.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``). The first element is
+            the JSON file path; ``--debug`` enables debug output.
+    """
+    args = sys.argv[1:] if argv is None else argv
+
     # Retrieve the JSON file path and optional debug flag from command line arguments
-    json_file: str = sys.argv[1]
-    debug = "--debug" in sys.argv
+    json_file = args[0]
+    debug = "--debug" in args
 
     # Load the JSON data from the file
     with open(json_file, "r") as f:
@@ -83,3 +91,7 @@ if __name__ == "__main__":
     # Parse the JSON data and write to GITHUB_OUTPUT
     collected_outputs = parse_json(data, debug=debug)
     set_github_output(collected_outputs, debug=debug)
+
+
+if __name__ == "__main__":
+    main()

--- a/json2vars_setter/features/matrix_update.py
+++ b/json2vars_setter/features/matrix_update.py
@@ -9,14 +9,10 @@ import json
 import logging
 import os
 import sys
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
-from json2vars_setter.version.core.base import BaseVersionFetcher, VersionInfo
-from json2vars_setter.version.fetchers.go import GoVersionFetcher
-from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
-from json2vars_setter.version.fetchers.python import PythonVersionFetcher
-from json2vars_setter.version.fetchers.ruby import RubyVersionFetcher
-from json2vars_setter.version.fetchers.rust import RustVersionFetcher
+from json2vars_setter.version.core.base import VersionInfo
+from json2vars_setter.version.registry import get_version_fetcher
 
 # Set up logging
 logging.basicConfig(
@@ -24,7 +20,7 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[logging.StreamHandler(sys.stdout)],
 )
-logger = logging.getLogger("update_matrix_dynamic")
+logger = logging.getLogger("matrix_update")
 
 
 class VersionStrategy:
@@ -38,34 +34,6 @@ class VersionStrategy:
     def is_valid(cls, strategy: str) -> bool:
         """Check if the strategy is valid"""
         return strategy in [cls.STABLE, cls.LATEST, cls.BOTH]
-
-
-def get_version_fetcher(language: str) -> BaseVersionFetcher:
-    """
-    Get the appropriate version fetcher for the language
-
-    Args:
-        language: Programming language name
-
-    Returns:
-        Instantiated version fetcher for the specified language
-
-    Raises:
-        ValueError: If language is not supported
-    """
-    fetcher_classes = {
-        "python": (PythonVersionFetcher, "python", "cpython"),
-        "nodejs": (NodejsVersionFetcher, "nodejs", "node"),
-        "ruby": (RubyVersionFetcher, "ruby", "ruby"),
-        "go": (GoVersionFetcher, "golang", "go"),
-        "rust": (RustVersionFetcher, "rust-lang", "rust"),
-    }
-
-    if language not in fetcher_classes:
-        raise ValueError(f"Unsupported language: {language}")
-
-    fetcher_class, owner, repo = fetcher_classes[language]
-    return fetcher_class()
 
 
 def get_versions_from_strategy(version_info: VersionInfo, strategy: str) -> List[str]:
@@ -242,8 +210,8 @@ def update_matrix_json(
         logger.info(f"  - Set to: {', '.join(info['versions'])}")
 
 
-def main() -> None:
-    """Main function to parse arguments and update JSON file"""
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the update-matrix command"""
     parser = argparse.ArgumentParser(
         description="""
 Dynamically update matrix.json with latest or stable versions.
@@ -253,16 +221,16 @@ without changing its structure.
 
 Examples:
   # Update all languages to latest versions with default JSON file
-  python json2vars_setter/update_matrix_dynamic.py --all latest
+  python -m json2vars_setter.features.matrix_update --all latest
 
   # Update specific languages with custom JSON file
-  python json2vars_setter/update_matrix_dynamic.py --json-file custom_matrix.json --python stable --nodejs latest
+  python -m json2vars_setter.features.matrix_update --json-file custom_matrix.json --python stable --nodejs latest
 
   # Dry run with all languages and custom JSON file
-  python json2vars_setter/update_matrix_dynamic.py --json-file ./matrix.json --all both --dry-run
+  python -m json2vars_setter.features.matrix_update --json-file ./matrix.json --all both --dry-run
 
   # Verbose output with specific languages and default JSON file
-  python json2vars_setter/update_matrix_dynamic.py --ruby stable --go latest -v
+  python -m json2vars_setter.features.matrix_update --ruby stable --go latest -v
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -308,7 +276,13 @@ Examples:
         "--verbose", "-v", action="store_true", help="Enable verbose logging"
     )
 
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Parse arguments and update the matrix JSON file"""
+    parser = build_parser()
+    args = parser.parse_args(argv)
 
     # Set log level based on verbosity
     if args.verbose:

--- a/json2vars_setter/features/version_cache.py
+++ b/json2vars_setter/features/version_cache.py
@@ -13,13 +13,9 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, DefaultDict, Dict, List, Optional, Set, Tuple
 
-from json2vars_setter.version.core.base import BaseVersionFetcher, VersionInfo
+from json2vars_setter.version.core.base import VersionInfo
 from json2vars_setter.version.core.utils import get_utc_now
-from json2vars_setter.version.fetchers.go import GoVersionFetcher
-from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
-from json2vars_setter.version.fetchers.python import PythonVersionFetcher
-from json2vars_setter.version.fetchers.ruby import RubyVersionFetcher
-from json2vars_setter.version.fetchers.rust import RustVersionFetcher
+from json2vars_setter.version.registry import get_version_fetcher
 
 # Set up logging
 logging.basicConfig(
@@ -27,7 +23,7 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[logging.StreamHandler(sys.stdout)],
 )
-logger = logging.getLogger("cache_version_info")
+logger = logging.getLogger("version_cache")
 
 # Default paths
 CACHE_DIR = Path(".github") / "json2vars-setter" / "cache"
@@ -274,34 +270,6 @@ class VersionCache:
         self.new_versions_found[language] = len(new_versions)
 
         return bool(new_versions), new_versions
-
-
-def get_version_fetcher(language: str) -> BaseVersionFetcher:
-    """
-    Get the appropriate version fetcher for the language
-
-    Args:
-        language: Programming language name
-
-    Returns:
-        Instantiated version fetcher for the specified language
-
-    Raises:
-        ValueError: If language is not supported
-    """
-    fetcher_classes = {
-        "python": (PythonVersionFetcher, "python", "cpython"),
-        "nodejs": (NodejsVersionFetcher, "nodejs", "node"),
-        "ruby": (RubyVersionFetcher, "ruby", "ruby"),
-        "go": (GoVersionFetcher, "golang", "go"),
-        "rust": (RustVersionFetcher, "rust-lang", "rust"),
-    }
-
-    if language not in fetcher_classes:
-        raise ValueError(f"Unsupported language: {language}")
-
-    fetcher_class, owner, repo = fetcher_classes[language]
-    return fetcher_class()
 
 
 def update_versions(
@@ -584,8 +552,8 @@ def generate_version_template(
     logger.info(f"Version template written to {output_file}")
 
 
-def main() -> None:
-    """Main function to parse arguments and update cache"""
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the version-cache command"""
     parser = argparse.ArgumentParser(
         description="""
 Cache version information for programming languages.
@@ -605,43 +573,43 @@ Common usage patterns:
 
 1. Basic updates:
   # Update all languages with default settings
-  python json2vars_setter/cache_version_info.py
+  python -m json2vars_setter.features.version_cache
 
 2. Efficient API usage:
   # Update only when cache is older than 7 days
-  python json2vars_setter/cache_version_info.py --max-age 7
+  python -m json2vars_setter.features.version_cache --max-age 7
 
   # Generate template only from existing cache (no API calls)
-  python json2vars_setter/cache_version_info.py --template-only
+  python -m json2vars_setter.features.version_cache --template-only
 
 3. Language-specific updates:
   # Update only Python and Node.js
-  python json2vars_setter/cache_version_info.py --languages python nodejs
+  python -m json2vars_setter.features.version_cache --languages python nodejs
 
   # Update only Python information in existing template (preserve other data)
-  python json2vars_setter/cache_version_info.py --template-only --languages python --keep-existing
+  python -m json2vars_setter.features.version_cache --template-only --languages python --keep-existing
 
 4. Advanced version management:
   # Add new versions while preserving existing cache
-  python json2vars_setter/cache_version_info.py --incremental
+  python -m json2vars_setter.features.version_cache --incremental
 
   # Accumulate up to 30 versions per language incrementally
-  python json2vars_setter/cache_version_info.py --incremental --count 30
+  python -m json2vars_setter.features.version_cache --incremental --count 30
 
 5. CI/CD workflow usage:
   # Separate cache updates and template generation
-  python json2vars_setter/cache_version_info.py --cache-only  # Periodic background job
-  python json2vars_setter/cache_version_info.py --template-only  # Pre-build step
+  python -m json2vars_setter.features.version_cache --cache-only  # Periodic background job
+  python -m json2vars_setter.features.version_cache --template-only  # Pre-build step
 
 Detailed examples:
   # Force update Python and Node.js with 20 versions each
-  python json2vars_setter/cache_version_info.py --languages python nodejs --force --count 20
+  python -m json2vars_setter.features.version_cache --languages python nodejs --force --count 20
 
   # Generate template with versions in ascending order (oldest first)
-  python json2vars_setter/cache_version_info.py --sort asc
+  python -m json2vars_setter.features.version_cache --sort asc
 
   # Update only Python version info in an existing project template
-  python json2vars_setter/cache_version_info.py --template-only --languages python --existing-template .github/json2vars-setter/python_project_matrix.json --template-file .github/json2vars-setter/python_project_matrix.json --keep-existing
+  python -m json2vars_setter.features.version_cache --template-only --languages python --existing-template .github/json2vars-setter/python_project_matrix.json --template-file .github/json2vars-setter/python_project_matrix.json --keep-existing
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -720,7 +688,13 @@ Detailed examples:
         "--verbose", "-v", action="store_true", help="Enable verbose logging"
     )
 
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Parse arguments and update the version cache"""
+    parser = build_parser()
+    args = parser.parse_args(argv)
 
     # Set log level based on verbosity
     if args.verbose:

--- a/json2vars_setter/version/registry.py
+++ b/json2vars_setter/version/registry.py
@@ -1,0 +1,44 @@
+"""
+Central registry mapping language names to their version fetchers.
+
+This is the single source of truth for which fetcher handles each language,
+shared by the matrix-update and version-cache features.
+"""
+
+from typing import Callable, Dict
+
+from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.fetchers.go import GoVersionFetcher
+from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
+from json2vars_setter.version.fetchers.python import PythonVersionFetcher
+from json2vars_setter.version.fetchers.ruby import RubyVersionFetcher
+from json2vars_setter.version.fetchers.rust import RustVersionFetcher
+
+# Supported languages mapped to their fetcher factories (each concrete fetcher
+# takes no constructor arguments).
+LANGUAGE_FETCHERS: Dict[str, Callable[[], BaseVersionFetcher]] = {
+    "python": PythonVersionFetcher,
+    "nodejs": NodejsVersionFetcher,
+    "ruby": RubyVersionFetcher,
+    "go": GoVersionFetcher,
+    "rust": RustVersionFetcher,
+}
+
+
+def get_version_fetcher(language: str) -> BaseVersionFetcher:
+    """
+    Get the appropriate version fetcher for the language
+
+    Args:
+        language: Programming language name
+
+    Returns:
+        Instantiated version fetcher for the specified language
+
+    Raises:
+        ValueError: If language is not supported
+    """
+    if language not in LANGUAGE_FETCHERS:
+        raise ValueError(f"Unsupported language: {language}")
+
+    return LANGUAGE_FETCHERS[language]()

--- a/tests/features/test_github_output.py
+++ b/tests/features/test_github_output.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from json2vars_setter.json_to_github_output import parse_json, set_github_output
+from json2vars_setter.features.github_output import parse_json, set_github_output
 
 MATRIX_JSON_PATH = "./tests/matrix_static.json"
 
@@ -167,7 +167,7 @@ def test_main_execution_with_matrix_json(monkeypatch: MonkeyPatch, tmpdir: Any) 
     result = subprocess.run(
         [
             "python",
-            "json2vars_setter/json_to_github_output.py",
+            "json2vars_setter/features/github_output.py",
             MATRIX_JSON_PATH,
             "--debug",
         ],

--- a/tests/features/test_matrix_update.py
+++ b/tests/features/test_matrix_update.py
@@ -7,9 +7,8 @@ from typing import Any, Dict, Generator, Optional
 import pytest
 from pytest_mock import MockerFixture
 
-from json2vars_setter.update_matrix_dynamic import (
+from json2vars_setter.features.matrix_update import (
     VersionStrategy,
-    get_version_fetcher,
     get_versions_from_strategy,
     load_json_file,
     main,
@@ -88,41 +87,6 @@ def test_version_strategy_validation() -> None:
     assert VersionStrategy.is_valid("invalid") is False
 
 
-def test_get_version_fetcher(mocker: MockerFixture) -> None:
-    """Test get_version_fetcher returns correct fetcher for each language"""
-    # Set up mocks for each fetcher
-    mock_python = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.PythonVersionFetcher"
-    )
-    mock_nodejs = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.NodejsVersionFetcher"
-    )
-    mock_ruby = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.RubyVersionFetcher"
-    )
-    mock_go = mocker.patch("json2vars_setter.update_matrix_dynamic.GoVersionFetcher")
-    mock_rust = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.RustVersionFetcher"
-    )
-
-    # Set return values
-    mock_python.return_value = mock_python
-    mock_nodejs.return_value = mock_nodejs
-    mock_ruby.return_value = mock_ruby
-    mock_go.return_value = mock_go
-    mock_rust.return_value = mock_rust
-
-    assert get_version_fetcher("python") == mock_python
-    assert get_version_fetcher("nodejs") == mock_nodejs
-    assert get_version_fetcher("ruby") == mock_ruby
-    assert get_version_fetcher("go") == mock_go
-    assert get_version_fetcher("rust") == mock_rust
-
-    # Test unsupported language
-    with pytest.raises(ValueError, match="Unsupported language: invalid"):
-        get_version_fetcher("invalid")
-
-
 def test_get_versions_from_strategy() -> None:
     """Test get_versions_from_strategy returns correct versions based on strategy"""
     version_info = VersionInfo(stable="2.0.0", latest="2.1.0")
@@ -184,7 +148,7 @@ def test_load_json_file(
 def test_save_json_file_io_error(mocker: MockerFixture, tmp_path: Path) -> None:
     """Test save_json_file handles IOError correctly"""
     # Set up mocks
-    mock_logger = mocker.patch("json2vars_setter.update_matrix_dynamic.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.matrix_update.logger")
     mock_exit = mocker.patch("sys.exit")
     test_data = {"test": "value"}
 
@@ -205,7 +169,7 @@ def test_save_json_file_io_error(mocker: MockerFixture, tmp_path: Path) -> None:
 def test_save_json_file_type_error(mocker: MockerFixture, tmp_path: Path) -> None:
     """Test save_json_file handles TypeError correctly"""
     # Set up mocks
-    mock_logger = mocker.patch("json2vars_setter.update_matrix_dynamic.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.matrix_update.logger")
     mock_exit = mocker.patch("sys.exit")
     test_data: Dict[str, Any] = {"test": "value"}
 
@@ -244,7 +208,7 @@ def test_save_json_file_content_already_ends_with_newline(
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
 
     # Mock logger to verify log messages
-    mock_logger = mocker.patch("json2vars_setter.update_matrix_dynamic.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.matrix_update.logger")
 
     # Test data
     test_data = {"test": "value"}
@@ -265,15 +229,15 @@ def test_update_matrix_json(
 ) -> None:
     """Test update_matrix_json updates the JSON correctly"""
     # Set up mocks
-    mock_load = mocker.patch("json2vars_setter.update_matrix_dynamic.load_json_file")
+    mock_load = mocker.patch("json2vars_setter.features.matrix_update.load_json_file")
     mock_load.return_value = sample_matrix_json.copy()
 
-    mock_save = mocker.patch("json2vars_setter.update_matrix_dynamic.save_json_file")
+    mock_save = mocker.patch("json2vars_setter.features.matrix_update.save_json_file")
 
     # Create a real MockVersionFetcher instance
     mock_fetcher_instance = MockVersionFetcher(stable="3.12", latest="3.13")
     mock_get_fetcher = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.get_version_fetcher"
+        "json2vars_setter.features.matrix_update.get_version_fetcher"
     )
     mock_get_fetcher.return_value = mock_fetcher_instance
 
@@ -318,14 +282,14 @@ def test_update_matrix_json(
 def test_main_function(mocker: MockerFixture) -> None:
     """Test the main function parses arguments correctly"""
     mock_update = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.update_matrix_json"
+        "json2vars_setter.features.matrix_update.update_matrix_json"
     )
 
     # Test with --all
     mocker.patch(
         "sys.argv",
         [
-            "update_matrix_dynamic.py",
+            "matrix_update.py",
             "--all",
             "stable",
             "--json-file",
@@ -350,7 +314,7 @@ def test_main_function(mocker: MockerFixture) -> None:
     mocker.patch(
         "sys.argv",
         [
-            "update_matrix_dynamic.py",
+            "matrix_update.py",
             "--python",
             "latest",
             "--nodejs",
@@ -367,7 +331,7 @@ def test_main_function(mocker: MockerFixture) -> None:
     )
 
     # Test with no language specified
-    mocker.patch("sys.argv", ["update_matrix_dynamic.py", "--verbose"])
+    mocker.patch("sys.argv", ["matrix_update.py", "--verbose"])
 
     with pytest.raises(SystemExit):
         main()
@@ -377,7 +341,7 @@ def test_main_function_integration(mocker: MockerFixture, temp_json_file: str) -
     """Integration test for the main function"""
     # Mock the fetch_versions to return controlled values
     mock_get_fetcher = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.get_version_fetcher"
+        "json2vars_setter.features.matrix_update.get_version_fetcher"
     )
     mock_get_fetcher.return_value = MockVersionFetcher(stable="3.12", latest="3.13")
 
@@ -385,7 +349,7 @@ def test_main_function_integration(mocker: MockerFixture, temp_json_file: str) -
     mocker.patch(
         "sys.argv",
         [
-            "update_matrix_dynamic.py",
+            "matrix_update.py",
             "--json-file",
             temp_json_file,
             "--python",
@@ -422,13 +386,13 @@ def test_update_matrix_json_missing_versions_key(mocker: MockerFixture) -> None:
     # Matrix without versions key
     matrix_without_versions = {"os": ["ubuntu-latest"]}
 
-    mock_load = mocker.patch("json2vars_setter.update_matrix_dynamic.load_json_file")
+    mock_load = mocker.patch("json2vars_setter.features.matrix_update.load_json_file")
     mock_load.return_value = matrix_without_versions
 
-    mock_save = mocker.patch("json2vars_setter.update_matrix_dynamic.save_json_file")
+    mock_save = mocker.patch("json2vars_setter.features.matrix_update.save_json_file")
 
     mock_get_fetcher = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.get_version_fetcher"
+        "json2vars_setter.features.matrix_update.get_version_fetcher"
     )
     mock_get_fetcher.return_value = MockVersionFetcher(stable="3.12", latest="3.13")
 
@@ -443,13 +407,13 @@ def test_update_matrix_json_new_language(
     mocker: MockerFixture, sample_matrix_json: Dict[str, Any]
 ) -> None:
     """Test update_matrix_json adds a new language if it doesn't exist"""
-    mock_load = mocker.patch("json2vars_setter.update_matrix_dynamic.load_json_file")
+    mock_load = mocker.patch("json2vars_setter.features.matrix_update.load_json_file")
     mock_load.return_value = sample_matrix_json.copy()
 
-    mock_save = mocker.patch("json2vars_setter.update_matrix_dynamic.save_json_file")
+    mock_save = mocker.patch("json2vars_setter.features.matrix_update.save_json_file")
 
     mock_get_fetcher = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.get_version_fetcher"
+        "json2vars_setter.features.matrix_update.get_version_fetcher"
     )
     mock_get_fetcher.return_value = MockVersionFetcher(stable="3.0.6", latest="3.1.6")
 
@@ -470,14 +434,14 @@ def test_update_matrix_json_empty_versions(mocker: MockerFixture) -> None:
     # Prepare sample data
     sample_data = {"versions": {"python": ["3.10"]}}
 
-    mock_load = mocker.patch("json2vars_setter.update_matrix_dynamic.load_json_file")
+    mock_load = mocker.patch("json2vars_setter.features.matrix_update.load_json_file")
     mock_load.return_value = sample_data
 
-    mock_save = mocker.patch("json2vars_setter.update_matrix_dynamic.save_json_file")
+    mock_save = mocker.patch("json2vars_setter.features.matrix_update.save_json_file")
 
     # Create a mock with empty versions
     mock_get_fetcher = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.get_version_fetcher"
+        "json2vars_setter.features.matrix_update.get_version_fetcher"
     )
     mock_fetcher = MockVersionFetcher(stable=None, latest=None)
     mock_get_fetcher.return_value = mock_fetcher
@@ -496,14 +460,14 @@ def test_backup_creation_success(mocker: MockerFixture) -> None:
     sample_data = {"versions": {"python": ["3.10"]}}
 
     # Set up mocks
-    mock_load = mocker.patch("json2vars_setter.update_matrix_dynamic.load_json_file")
+    mock_load = mocker.patch("json2vars_setter.features.matrix_update.load_json_file")
     mock_load.return_value = sample_data
 
     # Mock save_json_file
-    mocker.patch("json2vars_setter.update_matrix_dynamic.save_json_file")
+    mocker.patch("json2vars_setter.features.matrix_update.save_json_file")
 
     mock_get_fetcher = mocker.patch(
-        "json2vars_setter.update_matrix_dynamic.get_version_fetcher"
+        "json2vars_setter.features.matrix_update.get_version_fetcher"
     )
     mock_get_fetcher.return_value = MockVersionFetcher(stable="3.11", latest="3.12")
 
@@ -541,7 +505,7 @@ def test_real_backup_creation(temp_json_file: str) -> None:
         with pytest.MonkeyPatch.context() as mp:
             # Patch get_version_fetcher
             mp.setattr(
-                "json2vars_setter.update_matrix_dynamic.get_version_fetcher",
+                "json2vars_setter.features.matrix_update.get_version_fetcher",
                 lambda lang: MockVersionFetcher(stable="3.11", latest="3.12"),
             )
 

--- a/tests/features/test_version_cache.py
+++ b/tests/features/test_version_cache.py
@@ -9,10 +9,9 @@ from typing import Any, Dict, Generator, Optional
 import pytest
 from pytest_mock import MockFixture
 
-from json2vars_setter.cache_version_info import (
+from json2vars_setter.features.version_cache import (
     VersionCache,
     generate_version_template,
-    get_version_fetcher,
     main,
     update_versions,
 )
@@ -201,7 +200,7 @@ def test_version_cache_get_version_count(temp_cache_file: str) -> None:
 def test_version_cache_save(mocker: MockFixture) -> None:
     """Test save method"""
     # Mock logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     with tempfile.TemporaryDirectory() as temp_dir:
         cache_file = Path(temp_dir) / "cache.json"
@@ -360,43 +359,12 @@ def test_version_cache_merge_versions() -> None:
         assert cache.data["languages"]["python"]["stable"] == "3.10.0"
 
 
-def test_get_version_fetcher(mocker: MockFixture) -> None:
-    """Test get_version_fetcher returns correct fetcher for each language"""
-    # Set up mocks for each fetcher
-    mock_python = mocker.patch(
-        "json2vars_setter.cache_version_info.PythonVersionFetcher"
-    )
-    mock_nodejs = mocker.patch(
-        "json2vars_setter.cache_version_info.NodejsVersionFetcher"
-    )
-    mock_ruby = mocker.patch("json2vars_setter.cache_version_info.RubyVersionFetcher")
-    mock_go = mocker.patch("json2vars_setter.cache_version_info.GoVersionFetcher")
-    mock_rust = mocker.patch("json2vars_setter.cache_version_info.RustVersionFetcher")
-
-    # Set return values
-    mock_python.return_value = mock_python
-    mock_nodejs.return_value = mock_nodejs
-    mock_ruby.return_value = mock_ruby
-    mock_go.return_value = mock_go
-    mock_rust.return_value = mock_rust
-
-    assert get_version_fetcher("python") == mock_python
-    assert get_version_fetcher("nodejs") == mock_nodejs
-    assert get_version_fetcher("ruby") == mock_ruby
-    assert get_version_fetcher("go") == mock_go
-    assert get_version_fetcher("rust") == mock_rust
-
-    # Test unsupported language
-    with pytest.raises(ValueError, match="Unsupported language: invalid"):
-        get_version_fetcher("invalid")
-
-
 def test_update_versions(mocker: MockFixture) -> None:
     """Test update_versions function"""
     # Mock VersionCache
     mock_cache = mocker.MagicMock()
     mocker.patch(
-        "json2vars_setter.cache_version_info.VersionCache", return_value=mock_cache
+        "json2vars_setter.features.version_cache.VersionCache", return_value=mock_cache
     )
 
     # Setup mock merge_versions to return some changes
@@ -414,12 +382,12 @@ def test_update_versions(mocker: MockFixture) -> None:
         ],
     )
     mocker.patch(
-        "json2vars_setter.cache_version_info.get_version_fetcher",
+        "json2vars_setter.features.version_cache.get_version_fetcher",
         return_value=mock_fetcher,
     )
 
     # Mock logger
-    mocker.patch("json2vars_setter.cache_version_info.logger")
+    mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test update_versions for multiple languages
     result = update_versions(
@@ -454,7 +422,7 @@ def test_update_versions(mocker: MockFixture) -> None:
     # Test with exception in fetcher
     mock_fetcher.fetch_versions.side_effect = Exception("Test error")
     mocker.patch(
-        "json2vars_setter.cache_version_info.get_version_fetcher",
+        "json2vars_setter.features.version_cache.get_version_fetcher",
         return_value=mock_fetcher,
     )
 
@@ -464,7 +432,7 @@ def test_update_versions(mocker: MockFixture) -> None:
     # Test with rate limit error
     mock_fetcher.fetch_versions.side_effect = Exception("rate limit exceeded")
     mocker.patch(
-        "json2vars_setter.cache_version_info.get_version_fetcher",
+        "json2vars_setter.features.version_cache.get_version_fetcher",
         return_value=mock_fetcher,
     )
 
@@ -543,10 +511,12 @@ def test_main_function(mocker: MockFixture) -> None:
     args.verbose = False
 
     # Mock update_versions and generate_version_template
-    mock_update = mocker.patch("json2vars_setter.cache_version_info.update_versions")
+    mock_update = mocker.patch(
+        "json2vars_setter.features.version_cache.update_versions"
+    )
     mock_update.return_value = {"cache_data": {"languages": {}}}
     mock_generate = mocker.patch(
-        "json2vars_setter.cache_version_info.generate_version_template"
+        "json2vars_setter.features.version_cache.generate_version_template"
     )
 
     # Test main function
@@ -641,9 +611,11 @@ def test_main_with_force_flag(mocker: MockFixture) -> None:
     mocker.patch.object(Path, "exists", return_value=True)
 
     # Mock update_versions
-    mock_update = mocker.patch("json2vars_setter.cache_version_info.update_versions")
+    mock_update = mocker.patch(
+        "json2vars_setter.features.version_cache.update_versions"
+    )
     mock_update.return_value = {"cache_data": {"languages": {}}}
-    mocker.patch("json2vars_setter.cache_version_info.generate_version_template")
+    mocker.patch("json2vars_setter.features.version_cache.generate_version_template")
 
     main()
 
@@ -699,12 +671,14 @@ def test_main_with_verbose(mocker: MockFixture) -> None:
     args.verbose = True
 
     # Mock logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Mock update_versions
-    mock_update = mocker.patch("json2vars_setter.cache_version_info.update_versions")
+    mock_update = mocker.patch(
+        "json2vars_setter.features.version_cache.update_versions"
+    )
     mock_update.return_value = {"cache_data": {"languages": {}}}
-    mocker.patch("json2vars_setter.cache_version_info.generate_version_template")
+    mocker.patch("json2vars_setter.features.version_cache.generate_version_template")
 
     main()
 
@@ -739,12 +713,14 @@ def test_main_nonexistent_cache(mocker: MockFixture) -> None:
     mocker.patch.object(Path, "exists", return_value=False)
 
     # Mock logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Mock update_versions
-    mock_update = mocker.patch("json2vars_setter.cache_version_info.update_versions")
+    mock_update = mocker.patch(
+        "json2vars_setter.features.version_cache.update_versions"
+    )
     mock_update.return_value = {"cache_data": {"languages": {}}}
-    mocker.patch("json2vars_setter.cache_version_info.generate_version_template")
+    mocker.patch("json2vars_setter.features.version_cache.generate_version_template")
 
     main()
 
@@ -788,7 +764,7 @@ def test_main_integration(mocker: MockFixture) -> None:
     # Mock get_version_fetcher to return our mock fetcher
     mock_fetcher = MockVersionFetcher(stable="3.10.0", latest="3.11.0")
     mocker.patch(
-        "json2vars_setter.cache_version_info.get_version_fetcher",
+        "json2vars_setter.features.version_cache.get_version_fetcher",
         return_value=mock_fetcher,
     )
 
@@ -817,12 +793,12 @@ def test_main_integration(mocker: MockFixture) -> None:
 def test_generate_version_template_with_existing_mock(mocker: MockFixture) -> None:
     """Test the behavior of generate_version_template using mocks"""
     # Mock json.dumps within the module
-    mock_dumps = mocker.patch("json2vars_setter.cache_version_info.json.dumps")
+    mock_dumps = mocker.patch("json2vars_setter.features.version_cache.json.dumps")
     # Mock file opening
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
     # Mock json.load for existing file
     mock_load = mocker.patch(
-        "json2vars_setter.cache_version_info.json.load",
+        "json2vars_setter.features.version_cache.json.load",
         return_value={
             "os": ["ubuntu-latest"],
             "versions": {
@@ -835,7 +811,7 @@ def test_generate_version_template_with_existing_mock(mocker: MockFixture) -> No
     # Mock Path.exists to simulate an existing file
     mocker.patch("pathlib.Path.exists", return_value=True)
     # Mock logger for debugging and verification
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data
     data: Dict[str, Any] = {
@@ -947,11 +923,11 @@ def test_merge_versions_edge_cases() -> None:
 def test_generate_template_empty_releases(mocker: MockFixture) -> None:
     """Test template generation from an empty release list"""
     # Mock json.dumps within the module
-    mock_dumps = mocker.patch("json2vars_setter.cache_version_info.json.dumps")
+    mock_dumps = mocker.patch("json2vars_setter.features.version_cache.json.dumps")
     # Mock file opening
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
     # Mock logger for debugging
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data with empty releases
     empty_release_data: Dict[str, Any] = {
@@ -979,11 +955,11 @@ def test_generate_template_none_values(mocker: MockFixture) -> None:
     """Test template generation from data containing None values"""
     # Case 1: latest=None, stable=None
     # Mock json.dumps within the module
-    mock_dumps = mocker.patch("json2vars_setter.cache_version_info.json.dumps")
+    mock_dumps = mocker.patch("json2vars_setter.features.version_cache.json.dumps")
     # Mock file opening
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
     # Mock logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     none_values_data: Dict[str, Any] = {
         "languages": {
@@ -1008,9 +984,9 @@ def test_generate_template_none_values(mocker: MockFixture) -> None:
 
     # Case 2: latest=None, stable present
     # Reset mocks for next case
-    mock_dumps = mocker.patch("json2vars_setter.cache_version_info.json.dumps")
+    mock_dumps = mocker.patch("json2vars_setter.features.version_cache.json.dumps")
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     none_latest_data: Dict[str, Any] = {
         "languages": {
@@ -1038,9 +1014,9 @@ def test_generate_template_none_values(mocker: MockFixture) -> None:
 
     # Case 3: stable=None, latest present
     # Reset mocks for next case
-    mock_dumps = mocker.patch("json2vars_setter.cache_version_info.json.dumps")
+    mock_dumps = mocker.patch("json2vars_setter.features.version_cache.json.dumps")
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     none_stable_data: Dict[str, Any] = {
         "languages": {
@@ -1237,11 +1213,13 @@ def test_main_function_additional_scenarios(mocker: MockFixture) -> None:
     args.verbose = True
 
     # Set up mocks
-    mock_update = mocker.patch("json2vars_setter.cache_version_info.update_versions")
-    mock_generate = mocker.patch(
-        "json2vars_setter.cache_version_info.generate_version_template"
+    mock_update = mocker.patch(
+        "json2vars_setter.features.version_cache.update_versions"
     )
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_generate = mocker.patch(
+        "json2vars_setter.features.version_cache.generate_version_template"
+    )
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Mock Path.exists
     mocker.patch.object(Path, "exists", return_value=True)
@@ -1365,7 +1343,7 @@ def test_generate_version_template_output_count(
     in the output template (lines 543-546).
     """
     # Mock logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Create test data with many versions
     cache_data: Dict[str, Any] = {
@@ -1476,7 +1454,7 @@ def test_generate_version_template_existing_file_error_handling(
     output_file = tmp_path / "output_template.json"
 
     # Prepare mocked logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Call the function
     generate_version_template(
@@ -1502,7 +1480,7 @@ def test_generate_version_template_with_no_existing_file(mocker: MockFixture) ->
     Covers lines 469-474
     """
     # Prepare mocked logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Mock the path for a non-existent template file
     non_existent_file = Path("non_existent_template.json")
@@ -1557,7 +1535,7 @@ def test_generate_version_template_multiline_logging_paths(mocker: MockFixture) 
     Covers lines 527-528
     """
     # Prepare mocked logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Complete existing template data
     existing_data: Dict[str, Any] = {
@@ -1640,7 +1618,7 @@ def test_generate_version_template_keep_existing_no_recent_releases(
     Covers lines 527-528
     """
     # Prepare mocked logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Create existing template data
     existing_data = {
@@ -1903,7 +1881,7 @@ def test_generate_version_template_missing_branches(
     - 505->509: When latest equals stable (duplicate avoidance)
     """
     # Mock logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data setup
     cache_data: Dict[str, Any] = {
@@ -1938,7 +1916,7 @@ def test_generate_version_template_missing_branches(
         json.dump(existing_data, f)
 
     # Call the function
-    from json2vars_setter.cache_version_info import generate_version_template
+    from json2vars_setter.features.version_cache import generate_version_template
 
     generate_version_template(
         cache_data=cache_data,
@@ -1995,7 +1973,7 @@ def test_generate_version_template_empty_existing(
     Additional test to ensure coverage with empty existing_data
     """
     # Mock logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data
     cache_data: Dict[str, Any] = {
@@ -2023,7 +2001,7 @@ def test_generate_version_template_empty_existing(
         json.dump(existing_data, f)
 
     # Call the function
-    from json2vars_setter.cache_version_info import generate_version_template
+    from json2vars_setter.features.version_cache import generate_version_template
 
     generate_version_template(
         cache_data=cache_data,
@@ -2056,7 +2034,7 @@ def test_generate_version_template_uncovered_branches(
     When a version in recent_releases is already in the list (duplicate skipped)
     """
     # Mock logger
-    mock_logger = mocker.patch("json2vars_setter.cache_version_info.logger")
+    mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data setup
     cache_data: Dict[str, Any] = {
@@ -2080,7 +2058,7 @@ def test_generate_version_template_uncovered_branches(
     output_file = tmp_path / "output_template.json"
 
     # Call the function
-    from json2vars_setter.cache_version_info import generate_version_template
+    from json2vars_setter.features.version_cache import generate_version_template
 
     generate_version_template(
         cache_data=cache_data,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,25 +2,19 @@
 Tests for json2vars_setter.cli
 """
 
-import subprocess
-import sys
-from typing import Any, List
-
-from pytest import MonkeyPatch
+import pytest
+from pytest_mock import MockerFixture
 from typer.testing import CliRunner
 
 from json2vars_setter.cli import app
 
+runner = CliRunner()
+
 
 def test_usage_command() -> None:
     """Test for the usage command"""
-    # Set up the runner for CLI tests
-    runner = CliRunner()
-
-    # Execute the usage command
     result = runner.invoke(app, ["usage"])
 
-    # Test verification
     assert result.exit_code == 0
 
     # Verify the output content
@@ -35,173 +29,80 @@ def test_usage_command() -> None:
     assert "Update Matrix:" in result.stdout
 
 
-def test_cache_version_command(monkeypatch: MonkeyPatch) -> None:
-    """Test for the cache-version command"""
+def test_cache_version_passthrough(mocker: MockerFixture) -> None:
+    """cache-version forwards all extra args to version_cache.main in-process"""
+    mock_main = mocker.patch("json2vars_setter.cli.version_cache.main")
 
-    # Mock subprocess.run and sys.exit
-    def mock_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
-        return subprocess.CompletedProcess(
-            args=args[0], returncode=0, stdout="", stderr=""
-        )
+    result = runner.invoke(app, ["cache-version", "--languages", "python", "--force"])
 
-    exit_code: int = 0
-
-    def mock_exit(code: int = 0) -> None:
-        nonlocal exit_code
-        exit_code = code
-
-    monkeypatch.setattr(subprocess, "run", mock_run)
-    monkeypatch.setattr(sys, "exit", mock_exit)
-
-    # Set up the runner for CLI tests
-    runner = CliRunner()
-
-    # Execute the command
-    result = runner.invoke(app, ["cache-version"])
-
-    # Verification
     assert result.exit_code == 0
-    assert exit_code == 0
+    mock_main.assert_called_once_with(["--languages", "python", "--force"])
 
 
-def test_cache_version_with_help(monkeypatch: MonkeyPatch) -> None:
-    """Test for the cache-version command with help option"""
+def test_update_matrix_passthrough(mocker: MockerFixture) -> None:
+    """update-matrix forwards all extra args to matrix_update.main in-process"""
+    mock_main = mocker.patch("json2vars_setter.cli.matrix_update.main")
 
-    # Mock subprocess.run and sys.exit
-    def mock_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
-        return subprocess.CompletedProcess(
-            args=args[0], returncode=0, stdout="", stderr=""
-        )
+    result = runner.invoke(app, ["update-matrix", "--all", "latest"])
 
-    exit_code: int = 0
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with(["--all", "latest"])
 
-    def mock_exit(code: int = 0) -> None:
-        nonlocal exit_code
-        exit_code = code
 
-    monkeypatch.setattr(subprocess, "run", mock_run)
-    monkeypatch.setattr(sys, "exit", mock_exit)
+def test_systemexit_help_returns_zero(mocker: MockerFixture) -> None:
+    """A SystemExit with code 0 (e.g. --help) is treated as success"""
+    mocker.patch("json2vars_setter.cli.version_cache.main", side_effect=SystemExit(0))
 
-    # Set up the runner for CLI tests
-    runner = CliRunner()
-
-    # Execute the command (with help flag)
     result = runner.invoke(app, ["cache-version", "--help"])
 
-    # Verification
     assert result.exit_code == 0
-    assert exit_code == 0
 
 
-def test_cache_version_error(monkeypatch: MonkeyPatch) -> None:
-    """Test for error case of the cache-version command"""
-    # Mock subprocess.run to raise an error
-    exit_calls: List[int] = []
+def test_systemexit_none_returns_zero(mocker: MockerFixture) -> None:
+    """A SystemExit with code None is treated as success"""
+    mocker.patch(
+        "json2vars_setter.cli.version_cache.main", side_effect=SystemExit(None)
+    )
 
-    def mock_run_error(*args: Any, **kwargs: Any) -> None:
-        raise subprocess.CalledProcessError(1, "mock command")
+    result = runner.invoke(app, ["cache-version"])
 
-    def mock_exit(code: int = 0) -> None:
-        exit_calls.append(code)
-
-    monkeypatch.setattr(subprocess, "run", mock_run_error)
-    monkeypatch.setattr(sys, "exit", mock_exit)
-
-    # Set up the runner for CLI tests
-    runner = CliRunner()
-
-    # Execute the command
-    result = runner.invoke(app, ["cache-version"], catch_exceptions=False)
-
-    # Verification (the error message is written to stderr via typer.echo(err=True);
-    # Click >=8.2 keeps stderr separate from stdout in CliRunner)
-    assert "Error:" in result.stderr
-    # Verify that sys.exit was called with the appropriate code
-    assert len(exit_calls) > 0
-    assert 1 in exit_calls  # At least one call with code 1
+    assert result.exit_code == 0
 
 
-def test_update_matrix_command(monkeypatch: MonkeyPatch) -> None:
-    """Test for the update-matrix command"""
+def test_systemexit_nonzero_propagates_code(mocker: MockerFixture) -> None:
+    """A non-zero integer SystemExit (argparse usage error) propagates the code"""
+    mocker.patch("json2vars_setter.cli.matrix_update.main", side_effect=SystemExit(2))
 
-    # Mock subprocess.run and sys.exit
-    def mock_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
-        return subprocess.CompletedProcess(
-            args=args[0], returncode=0, stdout="", stderr=""
-        )
-
-    exit_code: int = 0
-
-    def mock_exit(code: int = 0) -> None:
-        nonlocal exit_code
-        exit_code = code
-
-    monkeypatch.setattr(subprocess, "run", mock_run)
-    monkeypatch.setattr(sys, "exit", mock_exit)
-
-    # Set up the runner for CLI tests
-    runner = CliRunner()
-
-    # Execute the command
     result = runner.invoke(app, ["update-matrix"])
 
-    # Verification
-    assert result.exit_code == 0
-    assert exit_code == 0
+    assert result.exit_code == 2
 
 
-def test_update_matrix_with_help(monkeypatch: MonkeyPatch) -> None:
-    """Test for the update-matrix command with help option"""
+def test_systemexit_non_integer_code_maps_to_one(mocker: MockerFixture) -> None:
+    """A SystemExit with a non-integer code maps to exit code 1"""
+    mocker.patch(
+        "json2vars_setter.cli.version_cache.main", side_effect=SystemExit("boom")
+    )
 
-    # Mock subprocess.run and sys.exit
-    def mock_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
-        return subprocess.CompletedProcess(
-            args=args[0], returncode=0, stdout="", stderr=""
-        )
+    result = runner.invoke(app, ["cache-version"])
 
-    exit_code: int = 0
-
-    def mock_exit(code: int = 0) -> None:
-        nonlocal exit_code
-        exit_code = code
-
-    monkeypatch.setattr(subprocess, "run", mock_run)
-    monkeypatch.setattr(sys, "exit", mock_exit)
-
-    # Set up the runner for CLI tests
-    runner = CliRunner()
-
-    # Execute the command (with help flag)
-    result = runner.invoke(app, ["update-matrix", "--help"])
-
-    # Verification
-    assert result.exit_code == 0
-    assert exit_code == 0
+    assert result.exit_code == 1
 
 
-def test_update_matrix_error(monkeypatch: MonkeyPatch) -> None:
-    """Test for error case of the update-matrix command"""
-    # Mock subprocess.run to raise an error
-    exit_calls: List[int] = []
+def test_generic_error_reported(mocker: MockerFixture) -> None:
+    """Any other exception is surfaced as a CLI error with exit code 1"""
+    mocker.patch(
+        "json2vars_setter.cli.version_cache.main",
+        side_effect=RuntimeError("kaboom"),
+    )
 
-    def mock_run_error(*args: Any, **kwargs: Any) -> None:
-        raise subprocess.CalledProcessError(1, "mock command")
+    result = runner.invoke(app, ["cache-version"])
 
-    def mock_exit(code: int = 0) -> None:
-        exit_calls.append(code)
+    assert result.exit_code == 1
+    # The error message is written to stderr via typer.echo(err=True);
+    # Click >=8.2 keeps stderr separate from stdout in CliRunner.
+    assert "Error: Failed to execute version_cache" in result.stderr
 
-    monkeypatch.setattr(subprocess, "run", mock_run_error)
-    monkeypatch.setattr(sys, "exit", mock_exit)
 
-    # Set up the runner for CLI tests
-    runner = CliRunner()
-
-    # Execute the command
-    result = runner.invoke(app, ["update-matrix"], catch_exceptions=False)
-
-    # Verification (the error message is written to stderr via typer.echo(err=True);
-    # Click >=8.2 keeps stderr separate from stdout in CliRunner)
-    assert "Error:" in result.stderr
-    # Verify that sys.exit was called with the appropriate code
-    assert len(exit_calls) > 0
-    assert 1 in exit_calls  # At least one call with code 1
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/version/test_registry.py
+++ b/tests/version/test_registry.py
@@ -1,0 +1,25 @@
+"""Tests for json2vars_setter.version.registry"""
+
+import pytest
+
+from json2vars_setter.version.fetchers.go import GoVersionFetcher
+from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
+from json2vars_setter.version.fetchers.python import PythonVersionFetcher
+from json2vars_setter.version.fetchers.ruby import RubyVersionFetcher
+from json2vars_setter.version.fetchers.rust import RustVersionFetcher
+from json2vars_setter.version.registry import get_version_fetcher
+
+
+def test_get_version_fetcher_returns_expected_type() -> None:
+    """get_version_fetcher returns the correct fetcher instance for each language"""
+    assert isinstance(get_version_fetcher("python"), PythonVersionFetcher)
+    assert isinstance(get_version_fetcher("nodejs"), NodejsVersionFetcher)
+    assert isinstance(get_version_fetcher("ruby"), RubyVersionFetcher)
+    assert isinstance(get_version_fetcher("go"), GoVersionFetcher)
+    assert isinstance(get_version_fetcher("rust"), RustVersionFetcher)
+
+
+def test_get_version_fetcher_unsupported_language() -> None:
+    """get_version_fetcher raises ValueError for an unknown language"""
+    with pytest.raises(ValueError, match="Unsupported language: invalid"):
+        get_version_fetcher("invalid")


### PR DESCRIPTION
## Summary

Architectural refactor (no change to the public interface — Action inputs/outputs and `json2vars` CLI commands/args are identical).

### Problems addressed (#489)
1. The three action stages sat as flat, peer modules at the package root with no grouping.
2. `get_version_fetcher` was duplicated byte-for-byte in two modules.
3. `cli.py` shelled out via `subprocess` instead of importing the logic.

### Changes
- **`features/` subpackage**: `json_to_github_output.py`→`features/github_output.py`, `update_matrix_dynamic.py`→`features/matrix_update.py`, `cache_version_info.py`→`features/version_cache.py`. Each exposes `build_parser()` + `main(argv=None)`.
- **`version/registry.py`**: single `get_version_fetcher()` + `LANGUAGE_FETCHERS` map; both features import it.
- **`cli.py`**: runs each feature's `main()` **in-process** (no subprocess); `--help` and usage errors map to the right exit code.
- **`action.yml`**: three `python -m json2vars_setter.features.<module>` paths updated.
- **Tests**: mirror the layout under `tests/features/`, repoint patch targets, move the de-duplicated fetcher test to `tests/version/test_registry.py`, and rewrite `tests/test_cli.py` for the in-process model.
- **Docs**: module references and architecture diagrams updated; `CLAUDE.md` documents the `features/` layout, the registry, and the in-process CLI.

Old module paths (`python -m json2vars_setter.cache_version_info` etc.) are removed cleanly (no compat shims), per the agreed plan.

### Verification
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues (37 source files)
- `pytest`: **203 passed, coverage 100%**
- Smoke-tested all entry points (`python -m json2vars_setter.features.*`, `json2vars usage`, `json2vars update-matrix --help`)

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)