### PR TITLE
:sparkles: Make the json2vars CLI guide users to the right command

### DIFF
--- a/json2vars_setter/cli.py
+++ b/json2vars_setter/cli.py
@@ -1,19 +1,30 @@
 #!/usr/bin/env python3
 """
-json2vars_setter CLI tool.
-Unified interface that runs the package features in-process via Typer.
+json2vars_setter CLI.
+
+A guided entry point that runs the package features in-process via Typer.
 """
 
-from typing import Callable, List
+from importlib.metadata import version as _dist_version
+from typing import Callable, List, Optional
 
 import typer
 
-from json2vars_setter.features import matrix_update, version_cache
+from json2vars_setter.features import github_output, matrix_update, version_cache
 
 # Create application instance
 app = typer.Typer(
     name="json2vars",
-    help="json2vars_setter CLI: Manages multiple scripts within the project",
+    help=(
+        "json2vars-setter CLI - manage the language versions behind your "
+        "GitHub Actions matrix.\n\n"
+        "Which command?  update-matrix: rewrite matrix.json with the latest/"
+        "stable versions.  cache-version: maintain a version cache and matrix "
+        "template (fewer API calls).  parse: expand a JSON file into "
+        "GITHUB_OUTPUT (automatic inside the Action).  "
+        "Run 'json2vars usage' for task-oriented examples."
+    ),
+    no_args_is_help=True,
 )
 
 # Pass-through settings: forward every argument to the feature's own argparse
@@ -23,6 +34,27 @@ _PASSTHROUGH = {
     "ignore_unknown_options": True,
     "help_option_names": [],
 }
+
+
+def _version_callback(value: bool) -> None:
+    """Print the installed package version and exit (for --version/-V)."""
+    if value:
+        typer.echo(f"json2vars-setter {_dist_version('json2vars-setter')}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the installed json2vars-setter version and exit.",
+    ),
+) -> None:
+    """json2vars-setter command-line interface."""
 
 
 def _run_feature(name: str, run: Callable[[List[str]], None], args: List[str]) -> None:
@@ -44,8 +76,18 @@ def _run_feature(name: str, run: Callable[[List[str]], None], args: List[str]) -
 
 
 @app.command(
+    "update-matrix",
+    help="Rewrite matrix.json in place with the latest/stable versions from official sources.",
+    context_settings=_PASSTHROUGH,
+)
+def update_matrix(ctx: typer.Context) -> None:
+    """Run the matrix-update feature. All arguments are passed through as-is."""
+    _run_feature("matrix_update", matrix_update.main, ctx.args)
+
+
+@app.command(
     "cache-version",
-    help="version_cache: Caches version information of programming languages",
+    help="Maintain a TTL version cache and generate a matrix template (fewer API calls).",
     context_settings=_PASSTHROUGH,
 )
 def cache_version(ctx: typer.Context) -> None:
@@ -54,41 +96,39 @@ def cache_version(ctx: typer.Context) -> None:
 
 
 @app.command(
-    "update-matrix",
-    help="matrix_update: Dynamically updates matrix.json with the latest or stable versions",
+    "parse",
+    help="Expand a JSON file into GITHUB_OUTPUT (runs automatically inside the Action).",
     context_settings=_PASSTHROUGH,
 )
-def update_matrix(ctx: typer.Context) -> None:
-    """Run the update-matrix feature. All arguments are passed through as-is."""
-    _run_feature("matrix_update", matrix_update.main, ctx.args)
+def parse(ctx: typer.Context) -> None:
+    """Run the github-output feature. Pass the JSON file path (and optional --debug)."""
+    _run_feature("github_output", github_output.main, ctx.args)
 
 
-@app.command("usage", help="Displays available commands and their usage")
+@app.command("usage", help="Task-oriented guide: which command for which goal.")
 def usage() -> None:
-    """Displays usage examples for all commands"""
-    typer.echo("=== json2vars_setter Usage Examples ===\n")
+    """Print a task-oriented guide mapping goals to commands."""
+    typer.echo("=== json2vars-setter - what do you want to do? ===\n")
 
-    typer.echo("Available commands:")
-    typer.echo("  cache-version    - Update cache version information")
-    typer.echo("  update-matrix    - Update matrix JSON")
-    typer.echo("  usage            - Display this usage information")
-    typer.echo("\nAdd the --help option to display detailed help for each command:")
-    typer.echo("  json2vars cache-version --help")
-    typer.echo("  json2vars update-matrix --help")
-    typer.echo("\nExamples:")
+    typer.echo("Pin the latest/stable versions into matrix.json:")
+    typer.echo("  json2vars update-matrix --all latest")
+    typer.echo("  json2vars update-matrix --python stable --nodejs latest")
+    typer.echo("")
 
-    typer.echo("● Cache Version Information:")
-    typer.echo("  # Update version information for all languages")
+    typer.echo("Maintain a version cache and matrix template (fewer GitHub API calls):")
     typer.echo("  json2vars cache-version")
-    typer.echo("  # Force update for specific languages")
     typer.echo("  json2vars cache-version --languages python nodejs --force")
     typer.echo("")
 
-    typer.echo("● Update Matrix:")
-    typer.echo("  # Update all languages to the latest version")
-    typer.echo("  json2vars update-matrix --all latest")
-    typer.echo("  # Update specific languages with different strategies")
-    typer.echo("  json2vars update-matrix --python stable --nodejs latest")
+    typer.echo("Parse a JSON file into GITHUB_OUTPUT (automatic inside the Action):")
+    typer.echo(
+        "  GITHUB_OUTPUT=out.txt json2vars parse .github/json2vars-setter/matrix.json"
+    )
+    typer.echo("")
+
+    typer.echo("See every option for a command:")
+    typer.echo("  json2vars update-matrix --help")
+    typer.echo("  json2vars cache-version --help")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,21 +12,48 @@ runner = CliRunner()
 
 
 def test_usage_command() -> None:
-    """Test for the usage command"""
+    """The usage command prints a task-oriented goal->command guide"""
     result = runner.invoke(app, ["usage"])
 
     assert result.exit_code == 0
 
-    # Verify the output content
-    assert "json2vars_setter Usage Examples" in result.stdout
-    assert "Available commands:" in result.stdout
-    assert "cache-version" in result.stdout
-    assert "update-matrix" in result.stdout
-    assert "usage" in result.stdout
+    # Task-oriented headings and the commands they map to
+    assert "what do you want to do?" in result.stdout
+    assert "json2vars update-matrix --all latest" in result.stdout
+    assert "json2vars cache-version" in result.stdout
+    assert "json2vars parse" in result.stdout
+    assert "GITHUB_OUTPUT" in result.stdout
 
-    # Verify examples
-    assert "Cache Version Information:" in result.stdout
-    assert "Update Matrix:" in result.stdout
+
+def test_no_args_shows_help() -> None:
+    """Running with no command shows the help/command list, not just an error"""
+    result = runner.invoke(app, [])
+
+    # no_args_is_help renders the full help (Usage + Commands). Click uses
+    # exit code 2 for a missing command; the point is the guidance is shown.
+    assert result.exit_code == 2
+    assert "Usage" in result.stdout
+    assert "update-matrix" in result.stdout
+    assert "cache-version" in result.stdout
+    assert "parse" in result.stdout
+
+
+def test_version_option() -> None:
+    """--version prints the installed package version and exits 0"""
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert "json2vars-setter" in result.stdout
+
+
+def test_parse_passthrough(mocker: MockerFixture) -> None:
+    """parse forwards the JSON path (and flags) to github_output.main in-process"""
+    mock_main = mocker.patch("json2vars_setter.cli.github_output.main")
+
+    result = runner.invoke(app, ["parse", "matrix.json", "--debug"])
+
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with(["matrix.json", "--debug"])
 
 
 def test_cache_version_passthrough(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary

Improve `cli.py` so the CLI helps users discover **what to do and which command to use** (#491). `cli.py` only; existing command behavior and argument pass-through are unchanged.

## Changes
1. **Guidance-first help**
   - `no_args_is_help=True`: bare `json2vars` now shows the help/command list instead of a red *Missing command* error.
   - Purpose-oriented top-level help; command descriptions rewritten around what they do / when to use them (no internal module names).
2. **`--version` / `-V`** prints the installed package version.
3. **`parse` command** exposes the github_output stage for local checks: `GITHUB_OUTPUT=out.txt json2vars parse <file>`.
4. **Task-oriented `usage`**: a goal→command (+ common flags) guide that also covers `parse` and notes the parse stage runs automatically inside the Action.

## Verification
- ruff / ruff format / mypy: clean
- pytest: **206 passed, coverage 100%**
- Smoke-tested `json2vars` (no args → help), `--version`, `usage`, `parse`, and `<cmd> --help` pass-through.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)