### PR TITLE
:sparkles: Adopt modern quality & security tooling (validate-pyproject, typos, modern-quality CI, SHA pinning, gitleaks)

### DIFF
--- a/.github/workflows/dependabot-auto-rebase.yml
+++ b/.github/workflows/dependabot-auto-rebase.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Mint a short-lived GitHub App token
         id: app-token
         if: steps.check.outputs.configured == 'true'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.DEPENDABOT_REBASE_APP_ID }}
           private-key: ${{ secrets.DEPENDABOT_REBASE_PRIVATE_KEY }}

--- a/.github/workflows/dependabot_prch.yml
+++ b/.github/workflows/dependabot_prch.yml
@@ -34,7 +34,7 @@ jobs:
       ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -66,7 +66,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Delete previous coverage comments
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -100,13 +100,13 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{matrix.python-version}}
       - name: Set timezone
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
           timezoneMacos: "Asia/Tokyo"
@@ -118,7 +118,7 @@ jobs:
           echo "TZ environment variable: ${TZ}"
           python -c "import datetime, platform; print(f'Python timezone: {datetime.datetime.now().astimezone().tzinfo}'); print(f'OS: {platform.system()}')"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
       - name: Install dependencies
@@ -146,7 +146,7 @@ jobs:
           fi
       - name: Pytest coverage comment
         id: coverageComment
-        uses: MishaKav/pytest-coverage-comment@v1.7.2
+        uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451 # v1.7.2
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           pytest-xml-coverage-path: ./coverage.xml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Set variables from JSON
@@ -28,17 +28,17 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 33836132+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ fromJson(steps.json2vars.outputs.versions_python)[0] }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
       - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
       - name: Create cache directory
         run: mkdir -p .cache
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           key: zensical-${{ env.cache_id }}
           path: .cache
@@ -49,7 +49,7 @@ jobs:
       - name: Build documentation
         run: uv run zensical build --clean
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -17,7 +17,7 @@ jobs:
       ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -56,12 +56,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
           # Cache is disabled because:
@@ -72,7 +72,7 @@ jobs:
           cache: false
 
       - name: Set timezone
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
           timezoneMacos: "Asia/Tokyo"
@@ -164,7 +164,7 @@ jobs:
           echo "color=$color" >> "$GITHUB_OUTPUT"
 
       - name: Create badge
-        uses: schneegans/dynamic-badges-action@v1.8.0
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: c334da204406866563668140885d170e

--- a/.github/workflows/modern-quality.yml
+++ b/.github/workflows/modern-quality.yml
@@ -40,9 +40,9 @@ jobs:
   validate-pyproject:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: false
       - name: Validate pyproject.toml
@@ -51,9 +51,9 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Spell check (typos, preview)
-        uses: crate-ci/typos@v1.47.1
+        uses: crate-ci/typos@44e2070e6017f834bf069503acb35ca0ca0b75f2 # v1.47.1
         continue-on-error: true
 
   zizmor:
@@ -61,9 +61,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: false
       - name: Audit workflows (zizmor, preview)
@@ -77,9 +77,9 @@ jobs:
   ty:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: false
       - name: Type check (ty, preview)
@@ -93,9 +93,9 @@ jobs:
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: false
       - name: Vulnerability scan (pip-audit, preview)

--- a/.github/workflows/modern-quality.yml
+++ b/.github/workflows/modern-quality.yml
@@ -1,0 +1,108 @@
+# Modern Quality (Preview)
+#
+# Non-blocking preview of modern security / quality tooling, adopted from
+# python-project-sandbox. Every analysis job is advisory (continue-on-error)
+# so it surfaces findings in the run summary without ever failing the build
+# or blocking a merge. The existing pre-commit + test workflows remain the
+# source of truth for required checks.
+#
+# Jobs:
+#   - validate-pyproject : schema-validate pyproject.toml (blocking; cheap & safe)
+#   - typos              : source-code spell check (preview)
+#   - zizmor             : GitHub Actions security audit (preview)
+#   - ty                 : Astral fast type checker (preview; mypy stays canonical)
+#   - pip-audit          : dependency vulnerability scan (preview)
+name: Modern Quality (Preview)
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - 'json2vars_setter/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-pyproject:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+      - name: Validate pyproject.toml
+        run: uvx validate-pyproject pyproject.toml
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Spell check (typos, preview)
+        uses: crate-ci/typos@v1.47.1
+        continue-on-error: true
+
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+      - name: Audit workflows (zizmor, preview)
+        continue-on-error: true
+        run: |
+          echo "## zizmor (GitHub Actions security, preview)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uvx zizmor --persona=regular .github/workflows 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  ty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+      - name: Type check (ty, preview)
+        continue-on-error: true
+        run: |
+          echo "## ty (Astral type checker, preview)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uv run --with ty ty check json2vars_setter 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+      - name: Vulnerability scan (pip-audit, preview)
+        continue-on-error: true
+        run: |
+          uv export --format requirements-txt --no-emit-project --all-extras -o audit-requirements.txt
+          echo "## pip-audit (dependency vulnerabilities, preview)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uvx pip-audit -r audit-requirements.txt 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/modern-quality.yml
+++ b/.github/workflows/modern-quality.yml
@@ -106,3 +106,16 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           uvx pip-audit -r audit-requirements.txt 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Secret scan (gitleaks, preview)
+        continue-on-error: true
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No GITLEAKS_LICENSE needed: this repo belongs to a personal account.

--- a/.github/workflows/nodejs_test.yml
+++ b/.github/workflows/nodejs_test.yml
@@ -18,7 +18,7 @@ jobs:
       ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -53,12 +53,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           # Enable caching of npm dependencies
@@ -66,7 +66,7 @@ jobs:
           cache-dependency-path: './examples/nodejs/package-lock.json'
 
       - name: Set timezone
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
           timezoneMacos: "Asia/Tokyo"
@@ -152,7 +152,7 @@ jobs:
           echo "color=$color" >> "$GITHUB_OUTPUT"
 
       - name: Create badge
-        uses: schneegans/dynamic-badges-action@v1.8.0
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 11f46ff9ef47d3362dabe767255b0d9e

--- a/.github/workflows/prch_test_matrix_json.yml
+++ b/.github/workflows/prch_test_matrix_json.yml
@@ -15,7 +15,7 @@ jobs:
       ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Delete previous coverage comments
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -80,24 +80,24 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set timezone
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
           timezoneMacos: "Asia/Tokyo"
           timezoneWindows: "Tokyo Standard Time"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -169,7 +169,7 @@ jobs:
           fi
       - name: Pytest coverage comment
         id: coverageComment
-        uses: MishaKav/pytest-coverage-comment@v1.7.2
+        uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451 # v1.7.2
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           pytest-xml-coverage-path: ./coverage.xml

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -20,7 +20,7 @@ jobs:
       ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -55,24 +55,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set timezone
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
           timezoneMacos: "Asia/Tokyo"
           timezoneWindows: "Tokyo Standard Time"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -148,7 +148,7 @@ jobs:
           echo "color=$color" >> "$GITHUB_OUTPUT"
 
       - name: Create badge
-        uses: schneegans/dynamic-badges-action@v1.8.0
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 26cb492ab0cfff920c516a622b2bfa44

--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -17,7 +17,7 @@ jobs:
       ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -56,19 +56,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.310.0
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
           working-directory: './examples/ruby'
 
       - name: Set timezone
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
           timezoneMacos: "Asia/Tokyo"
@@ -154,7 +154,7 @@ jobs:
           echo "color=$color" >> "$GITHUB_OUTPUT"
 
       - name: Create badge
-        uses: schneegans/dynamic-badges-action@v1.8.0
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 511ba5b5711e66c507292ba00cf0a219

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -17,7 +17,7 @@ jobs:
       ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -57,18 +57,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust-version }}
           components: rustfmt, clippy
 
       - name: Set timezone
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
           timezoneMacos: "Asia/Tokyo"
@@ -172,7 +172,7 @@ jobs:
           echo "color=$color" >> "$GITHUB_OUTPUT"
 
       - name: Create badge
-        uses: schneegans/dynamic-badges-action@v1.8.0
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 5e160d06cfffd42a8f0e4ae6e8e8f025

--- a/.github/workflows/update-requirements-after-dependabot.yml
+++ b/.github/workflows/update-requirements-after-dependabot.yml
@@ -20,13 +20,13 @@ jobs:
     if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_FOR_PUSHES }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 

--- a/.github/workflows/update-version-and-release.yml
+++ b/.github/workflows/update-version-and-release.yml
@@ -29,12 +29,12 @@ jobs:
   update-version-and-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_FOR_PUSHES }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
       - name: Configure Git
@@ -81,7 +81,7 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - name: Create Release
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: v${{ steps.update_version.outputs.new_version }}
           name: json2vars-setter-v${{ steps.update_version.outputs.new_version }}

--- a/.github/workflows/update_pre-commit_hooks.yml
+++ b/.github/workflows/update_pre-commit_hooks.yml
@@ -9,12 +9,12 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_FOR_PUSHES }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,20 @@ repos:
       # yaml syntax check
       - id: check-yaml
 
+  # https://github.com/abravalheri/validate-pyproject
+  # Validate pyproject.toml against the PEP 517/621 schema
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+      - id: validate-pyproject
+
+  # https://github.com/crate-ci/typos
+  # Source-code spell checker (config in pyproject.toml [tool.typos])
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.47.1
+    hooks:
+      - id: typos
+
   # https://github.com/shellcheck-py/shellcheck-py?tab=readme-ov-file#usage
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,11 @@ repos:
     hooks:
       - id: typos
 
+  # NOTE: gitleaks secret scanning runs in CI only (.github/workflows/modern-quality.yml).
+  # It is intentionally NOT a pre-commit hook: the golang/OpenSSL-linked gitleaks
+  # binary fails to run on this Windows dev environment, and with fail_fast: true a
+  # broken hook would block every local commit.
+
   # https://github.com/shellcheck-py/shellcheck-py?tab=readme-ov-file#usage
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,24 @@ uv run mypy --config-file=pyproject.toml
 # Pre-commit hooks (runs all checks)
 uv run pre-commit run --all-files
 
+# Validate pyproject.toml schema / spell check (also run by pre-commit)
+uvx validate-pyproject pyproject.toml
+uvx typos            # config in [tool.typos] (excludes via files.extend-exclude)
+
 # CLI usage help
 uv run json2vars --help
 ```
+
+### Modern quality preview (`.github/workflows/modern-quality.yml`)
+
+A non-blocking CI suite (every analysis job is `continue-on-error`, results land
+in the run summary): `validate-pyproject`, `typos`, `zizmor` (Actions security
+audit), `ty` (Astral type checker — mypy stays canonical), `pip-audit` (dependency
+CVEs), and `gitleaks` (secret scan, CI-only — no `GITLEAKS_LICENSE` needed for this
+personal-account repo). pre-commit + the test workflows remain the required checks.
+All `uses:` actions in `.github/workflows/**` and `action.yml` are pinned to commit
+SHAs (with the version tag as a trailing comment) — except the self-reference
+`uses: 7rikazhexde/json2vars-setter@vX.Y.Z`, which the Versioning Rule keeps as a tag.
 
 ## Architecture
 

--- a/action.yml
+++ b/action.yml
@@ -135,7 +135,7 @@ runs:
   steps:
     # Install uv (provisions Python 3.13 and caches dependencies automatically)
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         enable-cache: true
         cache-dependency-glob: "${{ github.action_path }}/uv.lock"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -115,7 +115,7 @@ Before starting any work, please check existing issues or create a new one to di
     Branches must follow the format: `<type>-<short-description>`.  
     Use the following prefixes based on the purpose of the branch:
 
-    - `feature-<description>`: For implementing new features (e.g., feature-newlang-supprt).
+    - `feature-<description>`: For implementing new features (e.g., feature-newlang-support).
     - `bugfix-<description>`: For fixing bugs (e.g., bugfix-fetch-python-version-error).
     - `docs-<description>`: For documentation updates (e.g., docs-update-readme).
     - `refactor-<description>`: For code refactoring without functional changes (e.g., refactor-cleanup-utils).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -220,7 +220,15 @@ Before starting any work, please check existing issues or create a new one to di
       - [markdownlint](https://github.com/DavidAnson/markdownlint) for Markdown files
       - [actionlint](https://github.com/rhysd/actionlint) for GitHub Actions workflows
       - [shellcheck](https://github.com/shellcheck-py/shellcheck-py) for shell script checking
+      - [validate-pyproject](https://github.com/abravalheri/validate-pyproject) for `pyproject.toml` schema validation
+      - [typos](https://github.com/crate-ci/typos) for source-code spell checking (config in `[tool.typos]`)
 - You can run all linters at once using: `uv run pre-commit run --all-files`
+
+**Modern Quality preview (CI, advisory)**
+
+- The [`modern-quality.yml`](https://github.com/7rikazhexde/json2vars-setter/blob/main/.github/workflows/modern-quality.yml) workflow runs an extra, **non-blocking** quality/security suite on pull requests and on `main` (every analysis job is `continue-on-error`; findings appear in the run summary). pre-commit and the test workflows remain the required checks.
+- Jobs: `validate-pyproject`, `typos`, [`zizmor`](https://github.com/woodruffw/zizmor) (GitHub Actions security audit), [`ty`](https://github.com/astral-sh/ty) (Astral fast type checker — mypy stays canonical), [`pip-audit`](https://github.com/pypa/pip-audit) (dependency CVE scan), and [`gitleaks`](https://github.com/gitleaks/gitleaks) (secret scan; CI-only).
+- All `uses:` actions in `.github/workflows/**` and `action.yml` are pinned to commit SHAs (with the version as a trailing comment) for supply-chain hardening. The example `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` references stay as version tags so usage examples track the released version.
 
 **Testing** (required)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,16 @@ select = ["E", "F", "I"]
 ignore = ["E402", "E501"]
 per-file-ignores = {}
 
+[tool.typos.files]
+extend-exclude = [
+    "uv.lock",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "htmlcov/",
+    "*.min.css",
+    "*.min.js",
+]
+
 [tool.mypy]
 files = ["json2vars_setter", "tests", "scripts"]
 python_version = "3.12"


### PR DESCRIPTION
Adopt linter / security / quality tooling inspired by [python-project-sandbox](https://github.com/7rikazhexde/python-project-sandbox), preferring more secure / safe / performant options. **No Python source changed** — config, workflows, and docs only.

## What's included (items 1–4)

1. **pre-commit additions** — `validate-pyproject` (PEP 517/621 schema) + `typos` (spell check, config in `[tool.typos]`). Fixed the single real typo found (`supprt` → `support` in `docs/contributing.md`).
2. **`modern-quality.yml`** — non-blocking preview CI suite; every analysis job is `continue-on-error`, results land in the run summary:
   - `validate-pyproject`, `typos`, `zizmor` (GitHub Actions security audit), `ty` (Astral fast type checker — **mypy stays canonical**), `pip-audit` (dependency CVE scan), `gitleaks` (secret scan).
3. **Action SHA pinning** — every `uses:` in `.github/workflows/**` and `action.yml` pinned to a commit SHA, with the version tag kept as a trailing comment (so Dependabot can still bump them). The self-reference `uses: 7rikazhexde/json2vars-setter@v1.2.0` in the example workflows is **intentionally exempt** per the CLAUDE.md Versioning Rule.
4. **gitleaks** — secret scanning, **CI-only** (no `GITLEAKS_LICENSE` needed for this personal-account repo). Deliberately **not** a pre-commit hook: the golang/OpenSSL-linked gitleaks binary fails to run on the Windows dev environment, and with `fail_fast: true` a broken hook would block every local commit. Rationale recorded in `.pre-commit-config.yaml`.

pre-commit + the existing test workflows remain the **required** checks; the modern-quality suite is advisory.

## Verification

- `uv run ruff check json2vars_setter` ✅
- `uv run ruff format --check json2vars_setter` ✅ (18 files already formatted)
- `uv run mypy --config-file=pyproject.toml` ✅ (no issues, 37 files)
- `uv run --with ty ty check json2vars_setter` ✅ (all checks passed)
- `typos` ✅ clean · `validate-pyproject pyproject.toml` ✅ valid
- All workflow YAML re-parsed OK after SHA pinning.

## Not in this PR (follow-up)

5. **release-please migration** — replacing the custom `update-version-and-release.yml` is a larger, harder-to-reverse change to the release pipeline (must preserve the version-reference sync rule). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)