### PR TITLE
:recycle: Enforce strict typing and ban Any across source and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,5 +92,11 @@ repos:
     rev: v2.1.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-requests==2.32.0.20240622]
+        # Type stubs / typed libs the isolated hook env needs so mypy strict mode
+        # (disallow_untyped_decorators) can resolve typer/pytest decorators.
+        additional_dependencies:
+          - types-requests==2.33.0.20260518
+          - typer==0.26.4
+          - pytest==9.0.3
+          - pytest-mock==3.15.1
         args: [--config-file=pyproject.toml]

--- a/json2vars_setter/cli.py
+++ b/json2vars_setter/cli.py
@@ -69,10 +69,10 @@ def _run_feature(name: str, run: Callable[[List[str]], None], args: List[str]) -
         code = exc.code
         if code is None or code == 0:
             return
-        raise typer.Exit(code if isinstance(code, int) else 1)
-    except Exception as exc:  # noqa: BLE001 - surface any failure as a CLI error
+        raise typer.Exit(code if isinstance(code, int) else 1) from exc
+    except Exception as exc:
         typer.echo(f"Error: Failed to execute {name} ({exc})", err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
 
 @app.command(

--- a/json2vars_setter/features/github_output.py
+++ b/json2vars_setter/features/github_output.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 
 def set_github_output(outputs: Dict[str, str], debug: bool) -> None:
@@ -30,7 +30,7 @@ def set_github_output(outputs: Dict[str, str], debug: bool) -> None:
         print(f"Debug: Written to GITHUB_OUTPUT -> {outputs}")
 
 
-def parse_json(data: Any, prefix: str = "", debug: bool = False) -> Dict[str, str]:
+def parse_json(data: object, prefix: str = "", debug: bool = False) -> Dict[str, str]:
     """
     Recursively parse JSON data and collect GitHub Actions outputs.
 

--- a/json2vars_setter/features/matrix_update.py
+++ b/json2vars_setter/features/matrix_update.py
@@ -9,9 +9,9 @@ import json
 import logging
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
-from json2vars_setter.version.core.base import VersionInfo
+from json2vars_setter.version.core.utils import JsonObject, VersionInfo
 from json2vars_setter.version.registry import get_version_fetcher
 
 # Set up logging
@@ -66,7 +66,7 @@ def get_versions_from_strategy(version_info: VersionInfo, strategy: str) -> List
     return versions
 
 
-def load_json_file(file_path: str) -> Dict[str, Any]:
+def load_json_file(file_path: str) -> JsonObject:
     """
     Load a JSON file
 
@@ -81,14 +81,14 @@ def load_json_file(file_path: str) -> Dict[str, Any]:
     """
     try:
         with open(file_path, "r") as f:
-            data: Dict[str, Any] = json.load(f)
+            data: JsonObject = json.load(f)
             return data
     except (FileNotFoundError, json.JSONDecodeError) as e:
         logger.error(f"Error loading JSON file: {e}")
         sys.exit(1)
 
 
-def save_json_file(file_path: str, data: Dict[str, Any]) -> None:
+def save_json_file(file_path: str, data: JsonObject) -> None:
     """
     Save a dictionary to a JSON file, ensuring it ends with a newline
 
@@ -143,6 +143,8 @@ def update_matrix_json(
     # Ensure versions key exists
     if "versions" not in matrix_data:
         matrix_data["versions"] = {}
+    # The "versions" section maps each language to its list of versions.
+    versions_section = cast(Dict[str, List[str]], matrix_data["versions"])
 
     # Backup original file
     if not dry_run:
@@ -155,7 +157,7 @@ def update_matrix_json(
             logger.warning(f"Could not create backup: {e}")
 
     # Keep track of changes
-    changes: Dict[str, Dict[str, Any]] = {}
+    changes: Dict[str, JsonObject] = {}
 
     # Update each language
     for language, strategy in language_strategies.items():
@@ -182,12 +184,12 @@ def update_matrix_json(
             }
 
             # Overwrite existing versions with new ones
-            if language not in matrix_data["versions"]:
-                matrix_data["versions"][language] = []
+            if language not in versions_section:
+                versions_section[language] = []
 
             # Replace entirely with new versions (no appending)
             logger.info(f"Replacing {language} versions with: {versions}")
-            matrix_data["versions"][language] = versions
+            versions_section[language] = versions
 
         except Exception as e:
             logger.error(f"Error updating {language} versions: {e}")
@@ -207,7 +209,7 @@ def update_matrix_json(
         logger.info(f"- {language} ({info['strategy']}):")
         logger.info(f"  - Latest: {info['latest']}")
         logger.info(f"  - Stable: {info['stable']}")
-        logger.info(f"  - Set to: {', '.join(info['versions'])}")
+        logger.info(f"  - Set to: {', '.join(cast(List[str], info['versions']))}")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/json2vars_setter/features/version_cache.py
+++ b/json2vars_setter/features/version_cache.py
@@ -11,10 +11,13 @@ import sys
 from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, List, Optional, Set, Tuple
+from typing import DefaultDict, Dict, List, Optional, Set, Tuple, cast
 
-from json2vars_setter.version.core.base import VersionInfo
-from json2vars_setter.version.core.utils import get_utc_now
+from json2vars_setter.version.core.utils import (
+    JsonObject,
+    VersionInfo,
+    get_utc_now,
+)
 from json2vars_setter.version.registry import get_version_fetcher
 
 # Set up logging
@@ -46,13 +49,13 @@ class VersionCache:
             cache_file: Path to the cache file
         """
         self.cache_file = cache_file
-        self.data: Dict[str, Any] = self._load_cache()
+        self.data: JsonObject = self._load_cache()
         self.version_count: int = self._get_version_count()
         self.new_versions_found: DefaultDict[str, int] = defaultdict(
             int
         )  # Number of newly found versions
 
-    def _load_cache(self) -> Dict[str, Any]:
+    def _load_cache(self) -> JsonObject:
         """
         Load the cache file if it exists
 
@@ -62,7 +65,7 @@ class VersionCache:
         if self.cache_file.exists():
             try:
                 with open(self.cache_file, "r") as f:
-                    data: Dict[str, Any] = json.load(f)
+                    data: JsonObject = json.load(f)
                 return data
             except (json.JSONDecodeError, IOError) as e:
                 logger.warning(f"Could not load cache file: {e}")
@@ -76,11 +79,25 @@ class VersionCache:
             "languages": {},
         }
 
+    def _languages(self) -> Dict[str, JsonObject]:
+        """Return the (mutable) per-language section of the cache."""
+        languages = self.data.setdefault("languages", {})
+        return cast(Dict[str, JsonObject], languages)
+
+    def _metadata(self) -> JsonObject:
+        """Return the (mutable) metadata section of the cache."""
+        metadata = self.data.setdefault("metadata", {})
+        return cast(JsonObject, metadata)
+
+    def _lang(self, language: str) -> JsonObject:
+        """Return the (mutable) cache entry for a single language."""
+        return self._languages().setdefault(language, {})
+
     def _get_version_count(self) -> int:
         """Get the number of versions obtained"""
-        if "metadata" in self.data and "version_count" in self.data["metadata"]:
-            version_count: int = self.data["metadata"]["version_count"]
-            return version_count
+        metadata = self.data.get("metadata")
+        if isinstance(metadata, dict) and "version_count" in metadata:
+            return cast(int, metadata["version_count"])
         return 0
 
     def save(self) -> None:
@@ -114,12 +131,12 @@ class VersionCache:
             logger.debug("Update needed because language cache does not exist")
             return True
 
-        if language not in self.data.get("languages", {}):
+        if language not in self._languages():
             logger.debug(f"{language}: Update needed because cache does not exist")
             return True
 
         # Update is needed if there is no cache for the language
-        language_info = self.data["languages"].get(language, {})
+        language_info = self._lang(language)
         if (
             not language_info
             or "recent_releases" not in language_info
@@ -133,7 +150,7 @@ class VersionCache:
         # Update is needed if the number of requested versions is greater than the cached count
         if requested_count > 0:
             current_versions = len(
-                self.data["languages"][language].get("recent_releases", [])
+                cast(List[object], self._lang(language).get("recent_releases", []))
             )
             if current_versions < requested_count:
                 logger.info(
@@ -142,8 +159,8 @@ class VersionCache:
                 return True
 
         # Check the last update date
-        last_updated = self.data["languages"][language].get("last_updated")
-        if not last_updated:
+        last_updated = self._lang(language).get("last_updated")
+        if not isinstance(last_updated, str):
             return True
 
         try:
@@ -177,30 +194,28 @@ class VersionCache:
         Returns:
             (Whether there were changes, Set of newly added versions)
         """
-        if "languages" not in self.data:
-            self.data["languages"] = {}
-
-        if language not in self.data["languages"]:
-            self.data["languages"][language] = {}
+        lang_entry = self._lang(language)
 
         # Get the existing version list
-        existing_versions = set()
-        existing_releases = []
+        existing_versions: Set[str] = set()
+        existing_releases: List[JsonObject] = []
 
-        if incremental and "recent_releases" in self.data["languages"][language]:
-            existing_releases = self.data["languages"][language]["recent_releases"]
+        if incremental and "recent_releases" in lang_entry:
+            existing_releases = cast(
+                List[JsonObject], lang_entry.get("recent_releases", [])
+            )
             for release in existing_releases:
                 if isinstance(release, dict) and "version" in release:
-                    existing_versions.add(release["version"])
+                    existing_versions.add(str(release["version"]))
 
         # Serialize new release information
-        new_releases = [vars(r) for r in version_info.recent_releases]
+        new_releases: List[JsonObject] = [vars(r) for r in version_info.recent_releases]
 
         # Track newly added versions
-        new_versions = set()
+        new_versions: Set[str] = set()
         for release in new_releases:
-            if release["version"] not in existing_versions:
-                new_versions.add(release["version"])
+            if str(release["version"]) not in existing_versions:
+                new_versions.add(str(release["version"]))
 
         # Merge existing and new releases in incremental mode
         if incremental:
@@ -209,7 +224,7 @@ class VersionCache:
 
             # Add only versions that do not exist in the existing releases to avoid duplicates
             for release in new_releases:
-                if release["version"] not in existing_versions:
+                if str(release["version"]) not in existing_versions:
                     merged_releases.append(release)
 
             # Sort by version (newest first) and keep the latest N releases
@@ -217,7 +232,7 @@ class VersionCache:
                 merged_releases.sort(
                     key=lambda x: [
                         int(p) if p.isdigit() else p
-                        for p in x["version"].replace("-", ".").split(".")
+                        for p in str(x["version"]).replace("-", ".").split(".")
                     ],
                     reverse=True,
                 )
@@ -231,20 +246,20 @@ class VersionCache:
         stable = version_info.stable
 
         # Maintain existing latest/stable if available and not obtained from API
-        if latest is None and "latest" in self.data["languages"][language]:
-            latest = self.data["languages"][language]["latest"]
+        if latest is None and "latest" in lang_entry:
+            latest = cast(Optional[str], lang_entry["latest"])
             logger.debug(
                 f"{language}: Maintained existing latest version as it was not obtained from API: {latest}"
             )
 
-        if stable is None and "stable" in self.data["languages"][language]:
-            stable = self.data["languages"][language]["stable"]
+        if stable is None and "stable" in lang_entry:
+            stable = cast(Optional[str], lang_entry["stable"])
             logger.debug(
                 f"{language}: Maintained existing stable version as it was not obtained from API: {stable}"
             )
 
         # Update cache
-        self.data["languages"][language].update(
+        lang_entry.update(
             {
                 "latest": latest,
                 "stable": stable,
@@ -254,16 +269,14 @@ class VersionCache:
         )
 
         # Update metadata
-        if "metadata" not in self.data:
-            self.data["metadata"] = {}
-
-        self.data["metadata"]["last_updated"] = get_utc_now().isoformat()
+        metadata = self._metadata()
+        metadata["last_updated"] = get_utc_now().isoformat()
 
         # Update count information
         if count > 0:
-            current_count = self.data["metadata"].get("version_count", 0)
+            current_count = cast(int, metadata.get("version_count", 0))
             if count > current_count:
-                self.data["metadata"]["version_count"] = count
+                metadata["version_count"] = count
                 logger.debug(f"Updated version count: {current_count} → {count}")
 
         # Save the number of newly added versions
@@ -279,7 +292,7 @@ def update_versions(
     count: int = 10,
     cache_file: Optional[Path] = None,
     incremental: bool = False,
-) -> Dict[str, Any]:
+) -> JsonObject:
     """
     Update version information for specified languages
 
@@ -363,7 +376,7 @@ def update_versions(
     cache.save()
 
     # Summary information
-    result = {
+    result: JsonObject = {
         "updated": list(updated_languages),
         "unchanged": list(unchanged_languages),
         "skipped": list(skipped_languages),
@@ -402,7 +415,7 @@ def update_versions(
 
 
 def generate_version_template(
-    cache_data: Dict[str, Any],
+    cache_data: JsonObject,
     output_file: Path,
     existing_file: Optional[Path] = None,
     languages: Optional[List[str]] = None,
@@ -423,16 +436,18 @@ def generate_version_template(
         output_count: Max number of versions per language to include in output (0=unlimited)
     """
     # Start with default template
-    template: Dict[str, Any] = {
+    template: JsonObject = {
         "os": DEFAULT_OS,
         "versions": {},
         "ghpages_branch": DEFAULT_GHPAGES_BRANCH,
     }
+    # The "versions" section maps each language to its list of versions.
+    template_versions = cast(Dict[str, List[str]], template["versions"])
 
     # Load existing template if available
-    existing_data: Dict[str, Any] = {}
+    existing_data: JsonObject = {}
     # Save the order of languages
-    existing_language_order = []
+    existing_language_order: List[str] = []
 
     if existing_file and existing_file.exists():
         try:
@@ -447,7 +462,9 @@ def generate_version_template(
 
             # Save the order of languages in the existing template
             if "versions" in existing_data:
-                existing_language_order = list(existing_data["versions"].keys())
+                existing_language_order = list(
+                    cast(Dict[str, List[str]], existing_data["versions"]).keys()
+                )
 
             logger.info(f"Maintained structure from existing file: {existing_file}")
         except (json.JSONDecodeError, IOError) as e:
@@ -457,11 +474,14 @@ def generate_version_template(
     reverse_sort = sort_order.lower() == "desc"
 
     # Create a temporary dictionary to store language information
-    temp_versions = {}
+    temp_versions: Dict[str, List[str]] = {}
 
     # First, copy existing versions if keep_existing is True
     if keep_existing and "versions" in existing_data:
-        for lang, version_list in existing_data.get("versions", {}).items():
+        existing_versions_map = cast(
+            Dict[str, List[str]], existing_data.get("versions", {})
+        )
+        for lang, version_list in existing_versions_map.items():
             # Only copy if not in specified languages (those will be updated from cache)
             if languages is None or lang not in languages:
                 temp_versions[lang] = version_list
@@ -470,31 +490,36 @@ def generate_version_template(
                 )
 
     # Now process languages from cache
-    for language, info in cache_data.get("languages", {}).items():
+    cache_languages = cast(Dict[str, JsonObject], cache_data.get("languages", {}))
+    for language, info in cache_languages.items():
         # Skip if languages is specified and this language is not in the list
         if languages and language not in languages:
             continue
 
-        if "recent_releases" in info and info["recent_releases"]:
+        if info.get("recent_releases"):
             # Extract versions from recent releases, excluding prereleases
             version_items: List[str] = []
-            for release in info.get("recent_releases", []):
+            recent_releases = cast(List[JsonObject], info.get("recent_releases", []))
+            for release in recent_releases:
                 if (
                     isinstance(release, dict)
                     and "version" in release
                     and not release.get("prerelease", False)
                 ):
                     # Ensure version isn't already in the list
-                    if release["version"] not in version_items:
-                        version_items.append(release["version"])
+                    version = str(release["version"])
+                    if version not in version_items:
+                        version_items.append(version)
 
             # Add stable and latest versions at the beginning
-            if info.get("stable") and info["stable"] not in version_items:
-                version_items.insert(0, info["stable"])
-            if info.get("latest"):
-                if info.get("latest") != info.get("stable"):
-                    if info["latest"] not in version_items:
-                        version_items.insert(0, info["latest"])
+            stable = info.get("stable")
+            if stable and str(stable) not in version_items:
+                version_items.insert(0, str(stable))
+            latest = info.get("latest")
+            if latest:
+                if latest != stable:
+                    if str(latest) not in version_items:
+                        version_items.insert(0, str(latest))
 
             # Sort supporting semantic versioning
             sorted_versions = sorted(
@@ -527,13 +552,13 @@ def generate_version_template(
     # First, maintain the existing order
     for lang in existing_language_order:
         if lang in temp_versions:
-            template["versions"][lang] = temp_versions[lang]
+            template_versions[lang] = temp_versions[lang]
             # Remove as it has been processed
             del temp_versions[lang]
 
     # Add remaining new languages
     for lang, version_list in temp_versions.items():
-        template["versions"][lang] = version_list
+        template_versions[lang] = version_list
 
     # Write template to file
     output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -720,7 +745,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     output_count = args.output_count if args.output_count > 0 else args.count
 
     # Skip cache update in template-only mode
-    cache_data: Optional[Dict[str, Any]] = None
+    cache_data: Optional[JsonObject] = None
     if not args.template_only:
         # Update versions
         result = update_versions(
@@ -731,7 +756,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             cache_file=args.cache_file,
             incremental=args.incremental,
         )
-        cache_data = result["cache_data"]
+        cache_data = cast(JsonObject, result["cache_data"])
     else:
         logger.info("Template-only mode: Skipping cache update")
         # Load existing cache for template generation

--- a/json2vars_setter/version/core/base.py
+++ b/json2vars_setter/version/core/base.py
@@ -1,18 +1,23 @@
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import requests
 
 from json2vars_setter.version.core.exceptions import GitHubAPIError, ParseError
-from json2vars_setter.version.core.utils import ReleaseInfo, VersionInfo, get_utc_now
+from json2vars_setter.version.core.utils import (
+    JsonObject,
+    ReleaseInfo,
+    VersionInfo,
+    get_utc_now,
+)
 
 
 class BaseVersionFetcher(ABC):
     """Base class for version fetchers that use GitHub tags"""
 
-    def __init__(self, github_owner: str, github_repo: str):
+    def __init__(self, github_owner: str, github_repo: str) -> None:
         """
         Initialize the fetcher with GitHub repository information
 
@@ -41,7 +46,7 @@ class BaseVersionFetcher(ABC):
                 {"Authorization": "token {}".format(self.github_token)}
             )
 
-    def _get_github_tags(self, count: Optional[int] = None) -> List[Dict[str, Any]]:
+    def _get_github_tags(self, count: Optional[int] = None) -> List[JsonObject]:
         """
         Fetch tags from GitHub API with pagination to ensure enough stable versions
 
@@ -54,7 +59,7 @@ class BaseVersionFetcher(ABC):
         Raises:
             GitHubAPIError: If there's an error accessing the GitHub API
         """
-        stable_tags: List[Dict[str, Any]] = []
+        stable_tags: List[JsonObject] = []
         page = 1
         per_page = 100  # Get more tags at once
         max_pages = 5  # Safety limit for pagination
@@ -109,17 +114,17 @@ class BaseVersionFetcher(ABC):
                         "Please set GITHUB_TOKEN environment variable "
                         "or wait for rate limit reset."
                     )
-                    raise GitHubAPIError(message)
+                    raise GitHubAPIError(message) from error
                 raise GitHubAPIError(
                     "Failed to fetch GitHub tags: {}".format(str(error))
-                )
+                ) from error
 
         result = stable_tags[:target_count] if target_count else stable_tags
         self.logger.debug("Returning %d stable tags", len(result))
         return result
 
     @abstractmethod
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """
         Check if a tag represents a stable release
 
@@ -132,7 +137,7 @@ class BaseVersionFetcher(ABC):
         pass
 
     @abstractmethod
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """
         Parse version information from a tag object
 
@@ -144,7 +149,7 @@ class BaseVersionFetcher(ABC):
         """
         pass
 
-    def _get_additional_info(self) -> Dict[str, Any]:
+    def _get_additional_info(self) -> JsonObject:
         """
         Get additional information specific to the language
 

--- a/json2vars_setter/version/core/utils.py
+++ b/json2vars_setter/version/core/utils.py
@@ -3,7 +3,14 @@ import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
+
+import requests
+
+# A parsed JSON object / GitHub REST response object with heterogeneous values.
+# JSON values are heterogeneous, so they are typed as ``object`` and narrowed at
+# the point of use (the project bans ``typing.Any``).
+JsonObject = Dict[str, object]
 
 
 @dataclass
@@ -13,7 +20,7 @@ class ReleaseInfo:
     version: str
     release_date: Optional[str] = None
     prerelease: bool = False
-    additional_info: Dict[str, Any] = field(default_factory=dict)
+    additional_info: JsonObject = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Post-initialization method to clean and standardize version info."""
@@ -24,13 +31,13 @@ class ReleaseInfo:
         if not self.prerelease:
             self.prerelease = is_prerelease(self.version)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Equality comparison based on version and prerelease status."""
         if not isinstance(other, ReleaseInfo):
             return NotImplemented
         return self.version == other.version and self.prerelease == other.prerelease
 
-    def __ne__(self, other: Any) -> bool:
+    def __ne__(self, other: object) -> bool:
         """Inequality comparison."""
         result = self.__eq__(other)
         if result is NotImplemented:
@@ -38,22 +45,22 @@ class ReleaseInfo:
         return not result
 
     # Explicitly disallow comparison operators
-    def __lt__(self, other: Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         raise TypeError(
             f"'<' not supported between instances of '{self.__class__.__name__}' and '{other.__class__.__name__}'"
         )
 
-    def __gt__(self, other: Any) -> bool:
+    def __gt__(self, other: object) -> bool:
         raise TypeError(
             f"'>' not supported between instances of '{self.__class__.__name__}' and '{other.__class__.__name__}'"
         )
 
-    def __le__(self, other: Any) -> bool:
+    def __le__(self, other: object) -> bool:
         raise TypeError(
             f"'<=' not supported between instances of '{self.__class__.__name__}' and '{other.__class__.__name__}'"
         )
 
-    def __ge__(self, other: Any) -> bool:
+    def __ge__(self, other: object) -> bool:
         raise TypeError(
             f"'>=' not supported between instances of '{self.__class__.__name__}' and '{other.__class__.__name__}'"
         )
@@ -66,7 +73,7 @@ class VersionInfo:
     latest: Optional[str] = None
     stable: Optional[str] = None
     recent_releases: List[ReleaseInfo] = field(default_factory=list)
-    details: Dict[str, Any] = field(default_factory=dict)
+    details: JsonObject = field(default_factory=dict)
 
     def has_error(self) -> bool:
         """Check if the version info contains an error."""
@@ -184,11 +191,11 @@ def is_prerelease(version: str) -> bool:
 
 
 def check_github_api(
-    session: Any,
+    session: requests.Session,
     github_owner: str,
     github_repo: str,
     count: int = 5,
-    filter_func: Optional[Callable[[Dict[str, Any]], bool]] = None,
+    filter_func: Optional[Callable[[JsonObject], bool]] = None,
 ) -> None:
     """
     Utility function to directly check GitHub API for tags
@@ -225,7 +232,7 @@ def check_github_api(
             for tag in filtered_tags[:count]:
                 print(f"- {tag.get('name')}")
     except Exception as e:
-        print(f"Error: {str(e)}")
+        print(f"Error: {e!s}")
 
 
 def get_utc_now() -> datetime:

--- a/json2vars_setter/version/fetchers/go.py
+++ b/json2vars_setter/version/fetchers/go.py
@@ -1,12 +1,12 @@
 import os
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple, cast
 
 import requests
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
 from json2vars_setter.version.core.exceptions import ParseError
-from json2vars_setter.version.core.utils import ReleaseInfo, setup_logging
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo, setup_logging
 
 
 class GoVersionFetcher(BaseVersionFetcher):
@@ -16,7 +16,7 @@ class GoVersionFetcher(BaseVersionFetcher):
         """Initialize with Go's GitHub repository information"""
         super().__init__("golang", "go")
 
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """
         Check if a tag represents a stable Go release
 
@@ -26,7 +26,7 @@ class GoVersionFetcher(BaseVersionFetcher):
         Returns:
             True if the tag represents a stable release, False otherwise
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
 
         # Go uses format "goX.Y.Z" for stable releases
         return (
@@ -47,7 +47,7 @@ class GoVersionFetcher(BaseVersionFetcher):
             )
         )
 
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """
         Parse version information from a Go tag
 
@@ -60,7 +60,7 @@ class GoVersionFetcher(BaseVersionFetcher):
         Raises:
             ParseError: If required version information cannot be parsed
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
         if not name:
             raise ParseError("No tag name found")
 
@@ -76,7 +76,7 @@ class GoVersionFetcher(BaseVersionFetcher):
             prerelease=prerelease,
             additional_info={
                 "tag_name": name,
-                "commit": {"sha": tag.get("commit", {}).get("sha")},
+                "commit": {"sha": cast(JsonObject, tag.get("commit", {})).get("sha")},
                 "tarball_url": tag.get("tarball_url"),
                 "zipball_url": tag.get("zipball_url"),
             },
@@ -111,7 +111,7 @@ class GoVersionFetcher(BaseVersionFetcher):
         match = re.match(r"(\d+)\.(\d+)\.(\d+)", latest_version)
 
         if match:
-            major, minor, patch = map(int, match.groups())
+            major, minor, _patch = map(int, match.groups())
             # Look for the previous minor version
             prev_minor = minor - 1
 
@@ -119,7 +119,7 @@ class GoVersionFetcher(BaseVersionFetcher):
             for release in releases:
                 r_match = re.match(r"(\d+)\.(\d+)\.(\d+)", release.version)
                 if r_match:
-                    r_major, r_minor, r_patch = map(int, r_match.groups())
+                    r_major, r_minor, _r_patch = map(int, r_match.groups())
                     if r_major == major and r_minor == prev_minor:
                         self.logger.info(
                             f"Using {release.version} as stable vs latest {latest_version}"
@@ -149,7 +149,7 @@ def check_api(
         return
 
     count = count or 5  # Set default value
-    stable_tags: List[Dict[str, Any]] = []
+    stable_tags: List[JsonObject] = []
     page = 1
     max_pages = 3  # Check up to 3 pages
 
@@ -179,7 +179,7 @@ def check_api(
             # Filter only stable tags
             new_stable_tags = []
             for tag in tags:
-                name = tag.get("name", "")
+                name = str(tag.get("name", ""))
                 if (
                     name.startswith("go")
                     and len(name.replace("go", "").split(".")) == 3

--- a/json2vars_setter/version/fetchers/nodejs.py
+++ b/json2vars_setter/version/fetchers/nodejs.py
@@ -1,11 +1,12 @@
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, cast
 
 import requests
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
 from json2vars_setter.version.core.exceptions import ParseError
 from json2vars_setter.version.core.utils import (
+    JsonObject,
     ReleaseInfo,
     check_github_api,
     setup_logging,
@@ -19,7 +20,7 @@ class NodejsVersionFetcher(BaseVersionFetcher):
         """Initialize with Node.js GitHub repository information"""
         super().__init__("nodejs", "node")
 
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """
         Check if a tag represents a stable Node.js release
 
@@ -29,7 +30,7 @@ class NodejsVersionFetcher(BaseVersionFetcher):
         Returns:
             True if the tag represents a stable release, False otherwise
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
 
         # Node.js uses format "vX.Y.Z" for stable releases
         return (
@@ -49,7 +50,7 @@ class NodejsVersionFetcher(BaseVersionFetcher):
             )
         )
 
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """
         Parse version information from a Node.js tag
 
@@ -62,7 +63,7 @@ class NodejsVersionFetcher(BaseVersionFetcher):
         Raises:
             ParseError: If required version information cannot be parsed
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
         if not name:
             raise ParseError("No tag name found")
 
@@ -81,14 +82,14 @@ class NodejsVersionFetcher(BaseVersionFetcher):
             prerelease=prerelease,
             additional_info={
                 "tag_name": name,
-                "commit": {"sha": tag.get("commit", {}).get("sha")},
+                "commit": {"sha": cast(JsonObject, tag.get("commit", {})).get("sha")},
                 "is_lts": is_lts,
                 "tarball_url": tag.get("tarball_url"),
                 "zipball_url": tag.get("zipball_url"),
             },
         )
 
-    def _get_additional_info(self) -> Dict[str, Any]:
+    def _get_additional_info(self) -> JsonObject:
         """
         Get additional Node.js specific information (LTS status)
 
@@ -214,7 +215,7 @@ class NodejsVersionFetcher(BaseVersionFetcher):
             self.logger.warning(f"Failed to fetch LTS versions: {e}")
             return []
 
-    def _get_specific_tag(self, tag_name: str) -> Optional[Dict[str, Any]]:
+    def _get_specific_tag(self, tag_name: str) -> Optional[JsonObject]:
         """
         Fetch a specific tag directly
 
@@ -280,13 +281,13 @@ class NodejsVersionFetcher(BaseVersionFetcher):
             self.logger.info(f"Retrieved {len(lts_info)} LTS versions from Node.js API")
             return lts_info
         except Exception as e:
-            self.logger.warning(f"Failed to fetch LTS information: {str(e)}")
+            self.logger.warning(f"Failed to fetch LTS information: {e!s}")
             return {}
 
 
-def nodejs_filter_func(tag: Dict[str, Any]) -> bool:
+def nodejs_filter_func(tag: JsonObject) -> bool:
     """Filter function for Node.js tags in API checker"""
-    name = tag.get("name", "")
+    name = str(tag.get("name", ""))
     return (
         name.startswith("v")
         and len(name.split(".")) == 3
@@ -357,7 +358,7 @@ if __name__ == "__main__":
                     if lts_count >= args.count:
                         break
         except Exception as e:
-            print(f"Error fetching LTS info: {str(e)}")
+            print(f"Error fetching LTS info: {e!s}")
 
     # Display header in verbose mode
     if args.verbose > 0:

--- a/json2vars_setter/version/fetchers/python.py
+++ b/json2vars_setter/version/fetchers/python.py
@@ -1,12 +1,13 @@
 import os
 import re
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple
 
 import requests
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
 from json2vars_setter.version.core.exceptions import ParseError
 from json2vars_setter.version.core.utils import (
+    JsonObject,
     ReleaseInfo,
     check_github_api,
     setup_logging,
@@ -20,7 +21,7 @@ class PythonVersionFetcher(BaseVersionFetcher):
         """Initialize with Python's GitHub repository information"""
         super().__init__("python", "cpython")
 
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """
         Check if a tag represents a stable Python release
 
@@ -30,7 +31,7 @@ class PythonVersionFetcher(BaseVersionFetcher):
         Returns:
             True if the tag represents a stable release, False otherwise
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
 
         # Python uses format "vX.Y.Z" for stable releases (3.x and 4.x series)
         return name.startswith(("v3", "v4")) and not any(
@@ -50,7 +51,7 @@ class PythonVersionFetcher(BaseVersionFetcher):
             ]
         )
 
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """
         Parse version information from a Python tag
 
@@ -63,7 +64,7 @@ class PythonVersionFetcher(BaseVersionFetcher):
         Raises:
             ParseError: If required version information cannot be parsed
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
         if not name:
             raise ParseError("No tag name found")
 
@@ -73,13 +74,16 @@ class PythonVersionFetcher(BaseVersionFetcher):
         # All filtered tags are considered stable
         prerelease = False
 
+        commit = tag.get("commit")
+        commit_sha = commit.get("sha") if isinstance(commit, dict) else None
+
         return ReleaseInfo(
             version=version,
             release_date=None,
             prerelease=prerelease,
             additional_info={
                 "tag_name": name,
-                "commit": {"sha": tag.get("commit", {}).get("sha")},
+                "commit": {"sha": commit_sha},
                 "tarball_url": tag.get("tarball_url"),
                 "zipball_url": tag.get("zipball_url"),
             },
@@ -114,7 +118,7 @@ class PythonVersionFetcher(BaseVersionFetcher):
         match = re.match(r"(\d+)\.(\d+)\.(\d+)", latest_version)
 
         if match:
-            major, minor, patch = map(int, match.groups())
+            major, minor, _patch = map(int, match.groups())
             # Look for the previous minor version
             prev_minor = minor - 1
 
@@ -122,7 +126,7 @@ class PythonVersionFetcher(BaseVersionFetcher):
             for release in releases:
                 r_match = re.match(r"(\d+)\.(\d+)\.(\d+)", release.version)
                 if r_match:
-                    r_major, r_minor, r_patch = map(int, r_match.groups())
+                    r_major, r_minor, _r_patch = map(int, r_match.groups())
                     if r_major == major and r_minor == prev_minor:
                         self.logger.info(
                             f"Using {release.version} as stable vs latest {latest_version}"
@@ -136,9 +140,9 @@ class PythonVersionFetcher(BaseVersionFetcher):
         return latest, latest
 
 
-def python_filter_func(tag: Dict[str, Any]) -> bool:
+def python_filter_func(tag: JsonObject) -> bool:
     """Filter function for Python tags in API checker"""
-    name = tag.get("name", "")
+    name = str(tag.get("name", ""))
 
     # Regular expression pattern to fully detect keywords indicating unstable versions
     unstable_pattern = r"(a|rc|b|beta|alpha|pre|preview|dev|test|nightly|snapshot)"

--- a/json2vars_setter/version/fetchers/ruby.py
+++ b/json2vars_setter/version/fetchers/ruby.py
@@ -1,12 +1,13 @@
 import os
 import re
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple, cast
 
 import requests
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
 from json2vars_setter.version.core.exceptions import ParseError
 from json2vars_setter.version.core.utils import (
+    JsonObject,
     ReleaseInfo,
     check_github_api,
     setup_logging,
@@ -20,7 +21,7 @@ class RubyVersionFetcher(BaseVersionFetcher):
         """Initialize with Ruby's GitHub repository information"""
         super().__init__("ruby", "ruby")
 
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """
         Check if a tag represents a stable Ruby release
 
@@ -30,7 +31,7 @@ class RubyVersionFetcher(BaseVersionFetcher):
         Returns:
             True if the tag represents a stable release, False otherwise
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
 
         # Ruby uses format "vX_Y_Z" for stable releases
         return (
@@ -53,7 +54,7 @@ class RubyVersionFetcher(BaseVersionFetcher):
             )
         )
 
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """
         Parse version information from a Ruby tag
 
@@ -66,7 +67,7 @@ class RubyVersionFetcher(BaseVersionFetcher):
         Raises:
             ParseError: If required version information cannot be parsed
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
         if not name:
             raise ParseError("No tag name found")
 
@@ -82,7 +83,7 @@ class RubyVersionFetcher(BaseVersionFetcher):
             prerelease=prerelease,
             additional_info={
                 "tag_name": name,
-                "commit": {"sha": tag.get("commit", {}).get("sha")},
+                "commit": {"sha": cast(JsonObject, tag.get("commit", {})).get("sha")},
                 "tarball_url": tag.get("tarball_url"),
                 "zipball_url": tag.get("zipball_url"),
             },
@@ -117,7 +118,7 @@ class RubyVersionFetcher(BaseVersionFetcher):
         match = re.match(r"(\d+)\.(\d+)\.(\d+)", latest_version)
 
         if match:
-            major, minor, patch = map(int, match.groups())
+            major, minor, _patch = map(int, match.groups())
             # Look for the previous minor version
             prev_minor = minor - 1
 
@@ -125,7 +126,7 @@ class RubyVersionFetcher(BaseVersionFetcher):
             for release in releases:
                 r_match = re.match(r"(\d+)\.(\d+)\.(\d+)", release.version)
                 if r_match:
-                    r_major, r_minor, r_patch = map(int, r_match.groups())
+                    r_major, r_minor, _r_patch = map(int, r_match.groups())
                     if r_major == major and r_minor == prev_minor:
                         self.logger.info(
                             f"Using {release.version} as stable vs latest {latest_version}"
@@ -139,9 +140,9 @@ class RubyVersionFetcher(BaseVersionFetcher):
         return latest, latest
 
 
-def ruby_filter_func(tag: Dict[str, Any]) -> bool:
+def ruby_filter_func(tag: JsonObject) -> bool:
     """Filter function for Ruby tags in API checker"""
-    name = tag.get("name", "")
+    name = str(tag.get("name", ""))
     return (
         name.startswith("v")
         and len(name.split("_")) == 3

--- a/json2vars_setter/version/fetchers/rust.py
+++ b/json2vars_setter/version/fetchers/rust.py
@@ -1,11 +1,12 @@
 import os
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple, cast
 
 import requests
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
 from json2vars_setter.version.core.exceptions import ParseError
 from json2vars_setter.version.core.utils import (
+    JsonObject,
     ReleaseInfo,
     check_github_api,
     setup_logging,
@@ -19,7 +20,7 @@ class RustVersionFetcher(BaseVersionFetcher):
         """Initialize with Rust's GitHub repository information"""
         super().__init__("rust-lang", "rust")
 
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """
         Check if a tag represents a stable Rust release
 
@@ -29,7 +30,7 @@ class RustVersionFetcher(BaseVersionFetcher):
         Returns:
             True if the tag represents a stable release, False otherwise
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
 
         # Rust uses format "1.xx.y" for stable releases
         return (
@@ -41,7 +42,7 @@ class RustVersionFetcher(BaseVersionFetcher):
             )
         )
 
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """
         Parse version information from a Rust tag
 
@@ -54,7 +55,7 @@ class RustVersionFetcher(BaseVersionFetcher):
         Raises:
             ParseError: If required version information cannot be parsed
         """
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
         if not name:
             raise ParseError("No tag name found")
 
@@ -70,13 +71,13 @@ class RustVersionFetcher(BaseVersionFetcher):
             prerelease=prerelease,
             additional_info={
                 "tag_name": name,
-                "commit": {"sha": tag.get("commit", {}).get("sha")},
+                "commit": {"sha": cast(JsonObject, tag.get("commit", {})).get("sha")},
                 "tarball_url": tag.get("tarball_url"),
                 "zipball_url": tag.get("zipball_url"),
             },
         )
 
-    def _get_additional_info(self) -> Dict[str, Any]:
+    def _get_additional_info(self) -> JsonObject:
         """
         Get additional Rust specific information (channel availability)
 
@@ -86,7 +87,7 @@ class RustVersionFetcher(BaseVersionFetcher):
         channel_info = self._fetch_rust_channel_info()
         return {"channel_info": channel_info}
 
-    def _fetch_rust_channel_info(self) -> Dict[str, Any]:
+    def _fetch_rust_channel_info(self) -> JsonObject:
         """
         Fetch Rust channel information from static.rust-lang.org
 
@@ -139,9 +140,9 @@ class RustVersionFetcher(BaseVersionFetcher):
         return latest, stable
 
 
-def rust_filter_func(tag: Dict[str, Any]) -> bool:
+def rust_filter_func(tag: JsonObject) -> bool:
     """Filter function for Rust tags in API checker"""
-    name = tag.get("name", "")
+    name = str(tag.get("name", ""))
     return (
         name.startswith("1.")
         and len(name.split(".")) == 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest-testmon>=2.1.4,<3.0.0",
     "ruff>=0.15.10,<0.16.0",
     "mypy>=1.20.1,<3.0.0",
+    "types-requests>=2.32.0,<3.0.0",
     "zensical>=0.0.32,<0.0.44",
 ]
 
@@ -63,7 +64,9 @@ exclude = [
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "B", "ANN", "RUF"]
+# ANN401 (ban typing.Any in annotations) is intentionally kept on to enforce the
+# project-wide "no Any" rule, alongside mypy's disallow_any_explicit.
 ignore = ["E402", "E501"]
 per-file-ignores = {}
 
@@ -80,14 +83,13 @@ extend-exclude = [
 [tool.mypy]
 files = ["json2vars_setter", "tests", "scripts"]
 python_version = "3.12"
+# Strict mode + an explicit ban on the Any type (project-wide, incl. tests).
+strict = true
+disallow_any_explicit = true
+warn_unreachable = true
 show_error_context = true
 show_column_numbers = true
 ignore_missing_imports = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-warn_return_any = true
-warn_unused_ignores = true
-warn_redundant_casts = true
 
 [tool.pytest.ini_options]
 testpaths = ["json2vars_setter", "tests"]

--- a/tests/features/test_github_output.py
+++ b/tests/features/test_github_output.py
@@ -2,12 +2,14 @@ import json
 import os
 import platform
 import subprocess
-from typing import Any
+from pathlib import Path
+from typing import Dict
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 from json2vars_setter.features.github_output import parse_json, set_github_output
+from json2vars_setter.version.core.utils import JsonObject
 
 MATRIX_JSON_PATH = "./tests/matrix_static.json"
 
@@ -76,15 +78,15 @@ def test_parse_matrix_static_json() -> None:
 
 def test_empty_json() -> None:
     """Test empty JSON data with parse_json"""
-    data: dict[str, Any] = {}
-    expected_outputs: dict[str, Any] = {}
+    data: JsonObject = {}
+    expected_outputs: Dict[str, str] = {}
     outputs = parse_json(data)
     assert outputs == expected_outputs
 
 
 def test_invalid_data_type() -> None:
     """Test exceptions when invalid data types are passed"""
-    data: Any = "invalid_type"
+    data: object = "invalid_type"
     with pytest.raises(TypeError):
         parse_json(data)
 
@@ -98,7 +100,7 @@ def test_parse_json_nested_list() -> None:
     assert outputs == expected_outputs
 
 
-def test_parse_json_scalar_list_with_debug(capsys: Any) -> None:
+def test_parse_json_scalar_list_with_debug(capsys: pytest.CaptureFixture[str]) -> None:
     """Test a top-level scalar list with debug enabled.
 
     Covers the debug-print branches for both the serialized list and each
@@ -119,9 +121,9 @@ def test_parse_json_scalar_list_with_debug(capsys: Any) -> None:
 # --- Test case for set_github_output() ---
 
 
-def test_set_github_output(monkeypatch: MonkeyPatch, tmpdir: Any) -> None:
+def test_set_github_output(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Test if output is written correctly using set_github_output"""
-    output_file = tmpdir.join("GITHUB_OUTPUT")
+    output_file = tmp_path / "GITHUB_OUTPUT"
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
 
     outputs = {"TEST_OUTPUT": "test_value"}
@@ -142,10 +144,10 @@ def test_github_output_not_set(monkeypatch: MonkeyPatch) -> None:
 
 
 def test_set_github_output_without_debug(
-    monkeypatch: MonkeyPatch, tmpdir: Any, capsys: Any
+    monkeypatch: MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Test that debug messages are not output when debug=False"""
-    github_output_file = tmpdir.join("GITHUB_OUTPUT")
+    github_output_file = tmp_path / "GITHUB_OUTPUT"
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output_file))
 
     outputs = {"TEST_OUTPUT": "test_value"}
@@ -158,9 +160,11 @@ def test_set_github_output_without_debug(
 # --- Test cases with sub-processes ---
 
 
-def test_main_execution_with_matrix_json(monkeypatch: MonkeyPatch, tmpdir: Any) -> None:
+def test_main_execution_with_matrix_json(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     """Test executing a script in a sub-process using matrix.json"""
-    github_output_file = tmpdir.join("GITHUB_OUTPUT")
+    github_output_file = tmp_path / "GITHUB_OUTPUT"
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output_file))
 
     # Script Execution
@@ -179,10 +183,10 @@ def test_main_execution_with_matrix_json(monkeypatch: MonkeyPatch, tmpdir: Any) 
     assert "Written to GITHUB_OUTPUT" in result.stdout
 
 
-def test_windows_path_handling(monkeypatch: MonkeyPatch, tmpdir: Any) -> None:
+def test_windows_path_handling(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Test handling of Windows-style paths"""
     # Normalize path using platform-specific separator
-    output_file = os.path.normpath(os.path.join(str(tmpdir), "GITHUB_OUTPUT"))
+    output_file = os.path.normpath(os.path.join(str(tmp_path), "GITHUB_OUTPUT"))
 
     # Create the directory if it doesn't exist
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
@@ -214,10 +218,10 @@ def test_windows_path_handling(monkeypatch: MonkeyPatch, tmpdir: Any) -> None:
 
 # Windows特有のテストをプラットフォームに関係なく実行するために修正
 # @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
-def test_windows_environment_vars(monkeypatch: MonkeyPatch, tmpdir: Any) -> None:
+def test_windows_environment_vars(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Test Windows-specific environment variable handling"""
     # モックするためにWindows固有の部分を一般化
-    output_file = os.path.normpath(os.path.join(str(tmpdir), "GITHUB_OUTPUT"))
+    output_file = os.path.normpath(os.path.join(str(tmp_path), "GITHUB_OUTPUT"))
 
     # Create the directory if it doesn't exist
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
@@ -227,7 +231,7 @@ def test_windows_environment_vars(monkeypatch: MonkeyPatch, tmpdir: Any) -> None
         pass
 
     monkeypatch.setenv("GITHUB_OUTPUT", output_file)
-    monkeypatch.setenv("TEMP", str(tmpdir))
+    monkeypatch.setenv("TEMP", str(tmp_path))
 
     # プラットフォームに依存しない方法でテストデータを作成
     temp_path = "%TEMP%/test"
@@ -256,9 +260,9 @@ def test_windows_environment_vars(monkeypatch: MonkeyPatch, tmpdir: Any) -> None
     assert f"MIXED_PATH={expected_mixed_path}\n" in content
 
 
-def test_empty_file_handling(monkeypatch: MonkeyPatch, tmpdir: Any) -> None:
+def test_empty_file_handling(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Test handling of empty files"""
-    output_file = os.path.normpath(os.path.join(str(tmpdir), "GITHUB_OUTPUT"))
+    output_file = os.path.normpath(os.path.join(str(tmp_path), "GITHUB_OUTPUT"))
 
     # Create the directory if it doesn't exist
     os.makedirs(os.path.dirname(output_file), exist_ok=True)

--- a/tests/features/test_matrix_update.py
+++ b/tests/features/test_matrix_update.py
@@ -2,7 +2,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, Generator, Optional
+from typing import Generator, Optional
 
 import pytest
 from pytest_mock import MockerFixture
@@ -15,17 +15,14 @@ from json2vars_setter.features.matrix_update import (
     save_json_file,
     update_matrix_json,
 )
-from json2vars_setter.version.core.base import (
-    BaseVersionFetcher,
-    ReleaseInfo,
-    VersionInfo,
-)
+from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo, VersionInfo
 
 # ---- Fixtures and Mocks ----
 
 
 @pytest.fixture
-def sample_matrix_json() -> Dict[str, Any]:
+def sample_matrix_json() -> JsonObject:
     """Sample matrix.json data for testing"""
     return {
         "os": ["ubuntu-latest", "windows-latest", "macos-latest"],
@@ -35,7 +32,7 @@ def sample_matrix_json() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def temp_json_file(sample_matrix_json: Dict[str, Any]) -> Generator[str, None, None]:
+def temp_json_file(sample_matrix_json: JsonObject) -> Generator[str, None, None]:
     """Create a temporary JSON file with sample data"""
     fd, path = tempfile.mkstemp(suffix=".json")
     with os.fdopen(fd, "w") as f:
@@ -49,7 +46,7 @@ class MockVersionFetcher(BaseVersionFetcher):
 
     def __init__(
         self, stable: Optional[str] = "2.0.0", latest: Optional[str] = "2.1.0"
-    ):
+    ) -> None:
         # Call the parent class constructor with dummy values
         super().__init__(github_owner="mock-owner", github_repo="mock-repo")
         self.mock_stable = stable
@@ -66,14 +63,14 @@ class MockVersionFetcher(BaseVersionFetcher):
             },
         )
 
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """Mock implementation of abstract method"""
         return True
 
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """Mock implementation of abstract method"""
         # Return stable ReleaseInfo from tag
-        return ReleaseInfo(version=tag.get("name", "1.0.0"), prerelease=False)
+        return ReleaseInfo(version=str(tag.get("name", "1.0.0")), prerelease=False)
 
 
 # ---- Test Functions ----
@@ -123,9 +120,7 @@ def test_get_versions_from_strategy() -> None:
         get_versions_from_strategy(version_info, "invalid")
 
 
-def test_load_json_file(
-    temp_json_file: str, sample_matrix_json: Dict[str, Any]
-) -> None:
+def test_load_json_file(temp_json_file: str, sample_matrix_json: JsonObject) -> None:
     """Test load_json_file loads JSON correctly"""
     data = load_json_file(temp_json_file)
     assert data == sample_matrix_json
@@ -150,7 +145,7 @@ def test_save_json_file_io_error(mocker: MockerFixture, tmp_path: Path) -> None:
     # Set up mocks
     mock_logger = mocker.patch("json2vars_setter.features.matrix_update.logger")
     mock_exit = mocker.patch("sys.exit")
-    test_data = {"test": "value"}
+    test_data: JsonObject = {"test": "value"}
 
     # Temporary file path for testing
     test_file = tmp_path / "test_file.json"
@@ -171,7 +166,7 @@ def test_save_json_file_type_error(mocker: MockerFixture, tmp_path: Path) -> Non
     # Set up mocks
     mock_logger = mocker.patch("json2vars_setter.features.matrix_update.logger")
     mock_exit = mocker.patch("sys.exit")
-    test_data: Dict[str, Any] = {"test": "value"}
+    test_data: JsonObject = {"test": "value"}
 
     # Temporary file path for testing
     test_file = tmp_path / "test_file.json"
@@ -211,7 +206,7 @@ def test_save_json_file_content_already_ends_with_newline(
     mock_logger = mocker.patch("json2vars_setter.features.matrix_update.logger")
 
     # Test data
-    test_data = {"test": "value"}
+    test_data: JsonObject = {"test": "value"}
 
     # Call the function
     save_json_file(str(tmp_path / "output.json"), test_data)
@@ -225,7 +220,7 @@ def test_save_json_file_content_already_ends_with_newline(
 
 
 def test_update_matrix_json(
-    mocker: MockerFixture, sample_matrix_json: Dict[str, Any]
+    mocker: MockerFixture, sample_matrix_json: JsonObject
 ) -> None:
     """Test update_matrix_json updates the JSON correctly"""
     # Set up mocks
@@ -404,7 +399,7 @@ def test_update_matrix_json_missing_versions_key(mocker: MockerFixture) -> None:
 
 
 def test_update_matrix_json_new_language(
-    mocker: MockerFixture, sample_matrix_json: Dict[str, Any]
+    mocker: MockerFixture, sample_matrix_json: JsonObject
 ) -> None:
     """Test update_matrix_json adds a new language if it doesn't exist"""
     mock_load = mocker.patch("json2vars_setter.features.matrix_update.load_json_file")

--- a/tests/features/test_version_cache.py
+++ b/tests/features/test_version_cache.py
@@ -4,7 +4,7 @@ import tempfile
 from collections import defaultdict
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Dict, Generator, Optional
+from typing import Dict, Generator, List, Optional, cast
 
 import pytest
 from pytest_mock import MockFixture
@@ -15,18 +15,44 @@ from json2vars_setter.features.version_cache import (
     main,
     update_versions,
 )
-from json2vars_setter.version.core.base import (
-    BaseVersionFetcher,
+from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.core.utils import (
+    JsonObject,
     ReleaseInfo,
     VersionInfo,
+    get_utc_now,
 )
-from json2vars_setter.version.core.utils import get_utc_now
 
 # ---- Fixtures and Mocks ----
 
 
+def _langs(cache: VersionCache) -> Dict[str, JsonObject]:
+    """Return the ``languages`` section narrowed to a typed mapping."""
+    return cast(Dict[str, JsonObject], cache.data["languages"])
+
+
+def _lang(cache: VersionCache, language: str) -> JsonObject:
+    """Return a single language entry narrowed to a typed mapping."""
+    return _langs(cache)[language]
+
+
+def _meta(cache: VersionCache) -> JsonObject:
+    """Return the ``metadata`` section narrowed to a typed mapping."""
+    return cast(JsonObject, cache.data["metadata"])
+
+
+def _obj(value: object) -> JsonObject:
+    """Narrow an arbitrary JSON value to a typed mapping."""
+    return cast(JsonObject, value)
+
+
+def _list(value: object) -> List[object]:
+    """Narrow an arbitrary JSON value to a typed list."""
+    return cast(List[object], value)
+
+
 @pytest.fixture
-def sample_cache_data() -> dict:
+def sample_cache_data() -> JsonObject:
     """Sample cache data for testing"""
     return {
         "metadata": {
@@ -58,7 +84,7 @@ def sample_cache_data() -> dict:
 
 
 @pytest.fixture
-def temp_cache_file(sample_cache_data: Dict[str, Any]) -> Generator[str, None, None]:
+def temp_cache_file(sample_cache_data: JsonObject) -> Generator[str, None, None]:
     """Create a temporary cache file with sample data"""
     fd, path = tempfile.mkstemp(suffix=".json")
     with os.fdopen(fd, "w") as f:
@@ -78,7 +104,7 @@ def temp_template_file() -> Generator[str, None, None]:
 
 
 @pytest.fixture
-def sample_template_data() -> Dict[str, Any]:
+def sample_template_data() -> JsonObject:
     """Sample template data for testing"""
     return {
         "os": ["ubuntu-latest", "windows-latest", "macos-latest"],
@@ -92,7 +118,7 @@ def sample_template_data() -> Dict[str, Any]:
 
 @pytest.fixture
 def temp_existing_template(
-    sample_template_data: Dict[str, Any],
+    sample_template_data: JsonObject,
 ) -> Generator[str, None, None]:
     """Create a temporary existing template file"""
     fd, path = tempfile.mkstemp(suffix=".json")
@@ -134,21 +160,21 @@ class MockVersionFetcher(BaseVersionFetcher):
             },
         )
 
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """Mock implementation of abstract method"""
         return True
 
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """Mock implementation of abstract method"""
         # Return stable ReleaseInfo from tag
-        return ReleaseInfo(version=tag.get("name", "1.0.0"), prerelease=False)
+        return ReleaseInfo(version=str(tag.get("name", "1.0.0")), prerelease=False)
 
 
 # ---- Basic Tests ----
 
 
 def test_version_cache_init(
-    temp_cache_file: str, sample_cache_data: Dict[str, Any]
+    temp_cache_file: str, sample_cache_data: JsonObject
 ) -> None:
     """Test initialization of VersionCache"""
     cache = VersionCache(Path(temp_cache_file))
@@ -164,8 +190,8 @@ def test_version_cache_load_nonexistent_file() -> None:
         cache_file = Path(temp_dir) / "nonexistent.json"
         cache = VersionCache(cache_file)
         assert "metadata" in cache.data
-        assert "last_updated" in cache.data["metadata"]
-        assert cache.data["metadata"]["version"] == "1.1"
+        assert "last_updated" in _meta(cache)
+        assert _meta(cache)["version"] == "1.1"
         assert "languages" in cache.data
         assert cache.version_count == 0
 
@@ -242,7 +268,7 @@ def test_version_cache_is_update_needed() -> None:
         assert cache.is_update_needed("python") is True
 
         # Add language to cache
-        cache.data["languages"]["python"] = {
+        _langs(cache)["python"] = {
             "latest": "3.11.0",
             "stable": "3.10.0",
             "recent_releases": [
@@ -256,23 +282,23 @@ def test_version_cache_is_update_needed() -> None:
 
         # Test with stale cache
         stale_date = (get_utc_now() - timedelta(days=2)).isoformat()
-        cache.data["languages"]["python"]["last_updated"] = stale_date
+        _langs(cache)["python"]["last_updated"] = stale_date
         assert cache.is_update_needed("python", max_age_days=1) is True
 
         # Test with requested count larger than cached count
-        cache.data["languages"]["python"]["last_updated"] = get_utc_now().isoformat()
+        _langs(cache)["python"]["last_updated"] = get_utc_now().isoformat()
         assert cache.is_update_needed("python", requested_count=2) is True
 
         # Test with empty recent_releases
-        cache.data["languages"]["python"]["recent_releases"] = []
+        _langs(cache)["python"]["recent_releases"] = []
         assert cache.is_update_needed("python") is True
 
         # Test with no recent_releases key
-        del cache.data["languages"]["python"]["recent_releases"]
+        del _langs(cache)["python"]["recent_releases"]
         assert cache.is_update_needed("python") is True
 
         # Test with invalid last_updated format
-        cache.data["languages"]["python"] = {
+        _langs(cache)["python"] = {
             "latest": "3.11.0",
             "stable": "3.10.0",
             "recent_releases": [{"version": "3.11.0"}],
@@ -281,7 +307,7 @@ def test_version_cache_is_update_needed() -> None:
         assert cache.is_update_needed("python") is True
 
         # Test with missing last_updated
-        del cache.data["languages"]["python"]["last_updated"]
+        del _langs(cache)["python"]["last_updated"]
         assert cache.is_update_needed("python") is True
 
 
@@ -304,10 +330,10 @@ def test_version_cache_merge_versions() -> None:
         # Test adding new language
         has_changes, new_versions = cache.merge_versions("python", version_info)
         assert has_changes is True
-        assert "python" in cache.data["languages"]
-        assert cache.data["languages"]["python"]["latest"] == "3.11.0"
-        assert cache.data["languages"]["python"]["stable"] == "3.10.0"
-        assert len(cache.data["languages"]["python"]["recent_releases"]) == 2
+        assert "python" in _langs(cache)
+        assert _langs(cache)["python"]["latest"] == "3.11.0"
+        assert _langs(cache)["python"]["stable"] == "3.10.0"
+        assert len(_list(_langs(cache)["python"]["recent_releases"])) == 2
         assert cache.new_versions_found["python"] == 2
         assert new_versions == {"3.11.0", "3.10.0"}
 
@@ -333,7 +359,7 @@ def test_version_cache_merge_versions() -> None:
         )
 
         # Set up the cache state to avoid sorting issues
-        cache.data["languages"]["python"]["recent_releases"] = [
+        _langs(cache)["python"]["recent_releases"] = [
             {"version": "3.12.0", "prerelease": False}
         ]
 
@@ -350,13 +376,13 @@ def test_version_cache_merge_versions() -> None:
         )
 
         # Cache existing values first
-        cache.data["languages"]["python"]["latest"] = "3.13.0"
-        cache.data["languages"]["python"]["stable"] = "3.10.0"
+        _langs(cache)["python"]["latest"] = "3.13.0"
+        _langs(cache)["python"]["stable"] = "3.10.0"
 
         # Existing data should be preserved if not obtained from API
         has_changes, new_versions = cache.merge_versions("python", version_info_none)
-        assert cache.data["languages"]["python"]["latest"] == "3.13.0"
-        assert cache.data["languages"]["python"]["stable"] == "3.10.0"
+        assert _langs(cache)["python"]["latest"] == "3.13.0"
+        assert _langs(cache)["python"]["stable"] == "3.10.0"
 
 
 def test_update_versions(mocker: MockFixture) -> None:
@@ -402,9 +428,9 @@ def test_update_versions(mocker: MockFixture) -> None:
     assert "new_versions_by_language" in result
     assert "cache_data" in result
 
-    assert "python" in result["updated"]
-    assert "nodejs" in result["unchanged"]
-    assert "3.11.0" in result["new_versions_by_language"]["python"]
+    assert "python" in _list(result["updated"])
+    assert "nodejs" in _list(result["unchanged"])
+    assert "3.11.0" in _list(_obj(result["new_versions_by_language"])["python"])
 
     # Test with custom cache file
     custom_cache_file = Path("custom_cache.json")
@@ -427,7 +453,7 @@ def test_update_versions(mocker: MockFixture) -> None:
     )
 
     result = update_versions(["python"], force=True)
-    assert "python" in result["failed"]
+    assert "python" in _list(result["failed"])
 
     # Test with rate limit error
     mock_fetcher.fetch_versions.side_effect = Exception("rate limit exceeded")
@@ -437,8 +463,8 @@ def test_update_versions(mocker: MockFixture) -> None:
     )
 
     result = update_versions(["python", "nodejs"], force=True)
-    assert "python" in result["failed"]
-    assert "nodejs" in result["skipped"]
+    assert "python" in _list(result["failed"])
+    assert "nodejs" in _list(result["skipped"])
 
     # Test default cache file path
     result = update_versions(["python"])
@@ -446,7 +472,7 @@ def test_update_versions(mocker: MockFixture) -> None:
 
 
 def test_generate_version_template(
-    sample_cache_data: Dict[str, Any], temp_template_file: str
+    sample_cache_data: JsonObject, temp_template_file: str
 ) -> None:
     """Test generate_version_template function - basic functionality"""
     # Test with default parameters
@@ -814,7 +840,7 @@ def test_generate_version_template_with_existing_mock(mocker: MockFixture) -> No
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data
-    data: Dict[str, Any] = {
+    data: JsonObject = {
         "languages": {
             "golang": {
                 "latest": "1.18.0",
@@ -882,7 +908,7 @@ def test_merge_versions_edge_cases() -> None:
     cache = VersionCache(Path("cache.json"))
 
     # Directly manipulate data to test specific states
-    cache.data["languages"]["python"] = {}  # Empty language entry
+    _langs(cache)["python"] = {}  # Empty language entry
 
     # Version info for testing
     version_info = VersionInfo(
@@ -898,10 +924,10 @@ def test_merge_versions_edge_cases() -> None:
         "python", version_info, incremental=True
     )
     assert has_changes is True
-    assert len(cache.data["languages"]["python"]["recent_releases"]) > 0
+    assert len(_list(_langs(cache)["python"]["recent_releases"])) > 0
 
     # Line 261: When the version is the same and incremental=True, it is judged as no change
-    cache.data["languages"]["python"]["recent_releases"] = [
+    _langs(cache)["python"]["recent_releases"] = [
         {"version": "3.11.0", "prerelease": False}
     ]
 
@@ -930,7 +956,7 @@ def test_generate_template_empty_releases(mocker: MockFixture) -> None:
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data with empty releases
-    empty_release_data: Dict[str, Any] = {
+    empty_release_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",
@@ -961,7 +987,7 @@ def test_generate_template_none_values(mocker: MockFixture) -> None:
     # Mock logger
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
-    none_values_data: Dict[str, Any] = {
+    none_values_data: JsonObject = {
         "languages": {
             "golang": {
                 "latest": None,
@@ -988,7 +1014,7 @@ def test_generate_template_none_values(mocker: MockFixture) -> None:
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
-    none_latest_data: Dict[str, Any] = {
+    none_latest_data: JsonObject = {
         "languages": {
             "golang": {
                 "latest": None,
@@ -1018,7 +1044,7 @@ def test_generate_template_none_values(mocker: MockFixture) -> None:
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
-    none_stable_data: Dict[str, Any] = {
+    none_stable_data: JsonObject = {
         "languages": {
             "golang": {
                 "latest": "1.18.0-beta",
@@ -1044,7 +1070,7 @@ def test_generate_template_with_versions_and_latest_stable(mocker: MockFixture) 
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
     mock_dumps = mocker.patch("json.dumps")
 
-    test_data: Dict[str, Any] = {
+    test_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",
@@ -1087,7 +1113,7 @@ def test_load_cache_additional_error_handling() -> None:
         # Verify that the default empty data structure is set
         assert "metadata" in cache.data
         assert "languages" in cache.data
-        assert "last_updated" in cache.data["metadata"]
+        assert "last_updated" in _meta(cache)
 
 
 def test_save_method_path_creation() -> None:
@@ -1126,7 +1152,7 @@ def test_merge_versions_with_partially_populated_cache() -> None:
     cache = VersionCache(Path("temp_cache.json"))
 
     # Partially populated cache data
-    cache.data["languages"]["python"] = {"latest": None, "stable": None}
+    _langs(cache)["python"] = {"latest": None, "stable": None}
 
     # Create version info
     version_info = VersionInfo(
@@ -1146,12 +1172,12 @@ def test_merge_versions_with_partially_populated_cache() -> None:
     # Verify results
     assert has_changes is True
     assert new_versions == {"3.11.0", "3.10.0"}
-    assert cache.data["languages"]["python"]["latest"] == "3.11.0"
-    assert cache.data["languages"]["python"]["stable"] == "3.10.0"
+    assert _langs(cache)["python"]["latest"] == "3.11.0"
+    assert _langs(cache)["python"]["stable"] == "3.10.0"
 
 
 def test_generate_version_template_complex_scenarios() -> None:
-    complex_data = {
+    complex_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.12.0",
@@ -1238,7 +1264,7 @@ def test_is_update_needed_empty_language_cache() -> None:
     Test is_update_needed() method when language cache does not exist
     """
     # Initialize VersionCache with mocked data
-    mock_data: Dict[str, Any] = {"metadata": {}}
+    mock_data: JsonObject = {"metadata": {}}
     cache = VersionCache(Path("dummy_cache.json"))
     cache.data = mock_data
 
@@ -1251,7 +1277,7 @@ def test_merge_versions_empty_languages_key() -> None:
     Test merge_versions() method when languages key does not exist
     """
     # Initialize VersionCache with mocked data
-    mock_data: Dict[str, Any] = {"metadata": {}}
+    mock_data: JsonObject = {"metadata": {}}
     cache = VersionCache(Path("dummy_cache.json"))
     cache.data = mock_data
 
@@ -1270,7 +1296,7 @@ def test_merge_versions_empty_languages_key() -> None:
 
     # Verify that languages key was added to the cache
     assert "languages" in cache.data
-    assert "python" in cache.data["languages"]
+    assert "python" in _langs(cache)
     assert has_changes is True
     assert new_versions == {"3.11.0", "3.10.0"}
 
@@ -1296,13 +1322,13 @@ def test_merge_versions_release_sorting() -> None:
     )
 
     # Call with count=3 to keep only the latest 3 releases
-    has_changes, new_versions = cache.merge_versions(
+    _has_changes, _new_versions = cache.merge_versions(
         "python", mock_version_info, count=3, incremental=True
     )
 
     # Verify results
-    python_releases = cache.data["languages"]["python"]["recent_releases"]
-    versions = [release["version"] for release in python_releases]
+    python_releases = _list(_langs(cache)["python"]["recent_releases"])
+    versions = [_obj(release)["version"] for release in python_releases]
 
     # Verify that the latest 3 releases are kept in descending order
     assert versions == ["3.11.0", "3.10.0", "3.9.0"]
@@ -1326,12 +1352,12 @@ def test_merge_versions_empty_metadata() -> None:
     )
 
     # Call merge_versions()
-    has_changes, new_versions = cache.merge_versions("python", mock_version_info)
+    _has_changes, _new_versions = cache.merge_versions("python", mock_version_info)
 
     # Verify that metadata was added
     assert "metadata" in cache.data
-    assert "last_updated" in cache.data["metadata"]
-    assert cache.data["metadata"]["last_updated"] is not None
+    assert "last_updated" in _meta(cache)
+    assert _meta(cache)["last_updated"] is not None
 
 
 def test_generate_version_template_output_count(
@@ -1346,7 +1372,7 @@ def test_generate_version_template_output_count(
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Create test data with many versions
-    cache_data: Dict[str, Any] = {
+    cache_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.12.0",
@@ -1437,7 +1463,7 @@ def test_generate_version_template_existing_file_error_handling(
         f.write("{invalid json")  # Invalid JSON file
 
     # Prepare mock cache data
-    mock_cache_data = {
+    mock_cache_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",
@@ -1487,7 +1513,7 @@ def test_generate_version_template_with_no_existing_file(mocker: MockFixture) ->
     non_existent_file.unlink(missing_ok=True)  # Ensure it is deleted
 
     # Prepare mock cache data
-    mock_cache_data = {
+    mock_cache_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",
@@ -1538,7 +1564,7 @@ def test_generate_version_template_multiline_logging_paths(mocker: MockFixture) 
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Complete existing template data
-    existing_data: Dict[str, Any] = {
+    existing_data: JsonObject = {
         "os": ["ubuntu-latest"],
         "versions": {
             "python": ["3.9.0", "3.8.0"],
@@ -1549,7 +1575,7 @@ def test_generate_version_template_multiline_logging_paths(mocker: MockFixture) 
     }
 
     # Mock cache data
-    mock_cache_data: Dict[str, Any] = {
+    mock_cache_data: JsonObject = {
         "languages": {
             "rust": {
                 "latest": "1.68.0",
@@ -1584,8 +1610,10 @@ def test_generate_version_template_multiline_logging_paths(mocker: MockFixture) 
                 Path(output_file.name),
                 existing_file=Path(existing_template_file.name),
                 keep_existing=True,
-                languages=list(existing_data["versions"].keys())
-                + ["rust"],  # Explicitly specify all languages
+                languages=[
+                    *_obj(existing_data["versions"]).keys(),
+                    "rust",
+                ],  # Explicitly specify all languages
             )
 
             # Read the output file
@@ -1630,7 +1658,7 @@ def test_generate_version_template_keep_existing_no_recent_releases(
     }
 
     # Cache data with empty recent_releases
-    mock_cache_data = {
+    mock_cache_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",
@@ -1680,7 +1708,7 @@ def test_is_update_needed_requested_count_branches() -> None:
     cache = VersionCache(Path("dummy_cache.json"))
 
     # Setup the language cache with a few versions
-    cache.data["languages"]["python"] = {
+    _langs(cache)["python"] = {
         "latest": "3.10.0",
         "stable": "3.9.0",
         "recent_releases": [
@@ -1704,7 +1732,7 @@ def test_is_update_needed_requested_count_branches() -> None:
     assert cache.is_update_needed("python", max_age_days=1, requested_count=-1) is False
 
     # Case 5: Another case to ensure both branches are taken - empty recent_releases
-    cache.data["languages"]["ruby"] = {
+    _langs(cache)["ruby"] = {
         "latest": "3.0.0",
         "stable": "2.7.0",
         "recent_releases": [],  # Empty list
@@ -1724,7 +1752,7 @@ def test_merge_versions_invalid_release_format() -> None:
     cache = VersionCache(Path("dummy_cache.json"))
 
     # Setup existing releases with invalid format
-    cache.data["languages"]["python"] = {
+    _langs(cache)["python"] = {
         "latest": "3.10.0",
         "stable": "3.9.0",
         "recent_releases": [
@@ -1767,7 +1795,7 @@ def test_merge_versions_invalid_release_format() -> None:
 
     # Get all valid version strings from the merged result
     valid_versions = set()
-    for release in cache.data["languages"]["python"]["recent_releases"]:
+    for release in _list(_langs(cache)["python"]["recent_releases"]):
         if isinstance(release, dict) and "version" in release:
             valid_versions.add(release["version"])
 
@@ -1798,7 +1826,7 @@ def test_merge_versions_count_metadata_update() -> None:
     }
 
     # Setup the language cache
-    cache.data["languages"]["python"] = {
+    _langs(cache)["python"] = {
         "latest": "3.10.0",
         "stable": "3.9.0",
         "recent_releases": [
@@ -1818,23 +1846,23 @@ def test_merge_versions_count_metadata_update() -> None:
     )
 
     # Test case 1: count < current_count (should not update version_count)
-    has_changes, new_versions = cache.merge_versions(
+    _has_changes, _new_versions = cache.merge_versions(
         "python", version_info, count=3, incremental=True
     )
 
     # Verify version_count was not updated
-    assert cache.data["metadata"]["version_count"] == 5, (
+    assert _meta(cache)["version_count"] == 5, (
         "version_count should not be updated when count < current_count"
     )
 
     # Test case 2: count > current_count (should update version_count)
     # This should trigger the branch at lines 268-273
-    has_changes, new_versions = cache.merge_versions(
+    _has_changes, _new_versions = cache.merge_versions(
         "python", version_info, count=10, incremental=True
     )
 
     # Verify version_count was updated
-    assert cache.data["metadata"]["version_count"] == 10, (
+    assert _meta(cache)["version_count"] == 10, (
         "version_count should be updated when count > current_count"
     )
 
@@ -1844,7 +1872,7 @@ def test_merge_versions_count_metadata_update() -> None:
     # Don't set metadata explicitly to test initialization behavior
 
     # Setup the language cache
-    cache2.data["languages"]["python"] = {
+    _langs(cache2)["python"] = {
         "latest": "3.10.0",
         "stable": "3.9.0",
         "recent_releases": [
@@ -1855,14 +1883,14 @@ def test_merge_versions_count_metadata_update() -> None:
     }
 
     # Call merge_versions with count > 0
-    has_changes, new_versions = cache2.merge_versions(
+    _has_changes, _new_versions = cache2.merge_versions(
         "python", version_info, count=7, incremental=True
     )
 
     # Verify metadata was created and version_count was set
     assert "metadata" in cache2.data
-    assert "version_count" in cache2.data["metadata"]
-    assert cache2.data["metadata"]["version_count"] == 7
+    assert "version_count" in _meta(cache2)
+    assert _meta(cache2)["version_count"] == 7
 
 
 # Assuming these are defined in your module
@@ -1884,7 +1912,7 @@ def test_generate_version_template_missing_branches(
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data setup
-    cache_data: Dict[str, Any] = {
+    cache_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",
@@ -1902,7 +1930,7 @@ def test_generate_version_template_missing_branches(
     }
 
     # Existing template with minimal data (missing 'os' and 'ghpages_branch')
-    existing_data: Dict[str, Any] = {
+    existing_data: JsonObject = {
         "versions": {"python": ["3.8.0"]}
         # Intentionally omitting 'os' and 'ghpages_branch' to hit 469->471 and 471->474
     }
@@ -1976,7 +2004,7 @@ def test_generate_version_template_empty_existing(
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data
-    cache_data: Dict[str, Any] = {
+    cache_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",
@@ -1990,7 +2018,7 @@ def test_generate_version_template_empty_existing(
     }
 
     # Empty existing template
-    existing_data: Dict[str, Any] = {}
+    existing_data: JsonObject = {}
 
     # Create temporary files
     existing_file = tmp_path / "empty_existing.json"
@@ -2037,7 +2065,7 @@ def test_generate_version_template_uncovered_branches(
     mock_logger = mocker.patch("json2vars_setter.features.version_cache.logger")
 
     # Test data setup
-    cache_data: Dict[str, Any] = {
+    cache_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",
@@ -2120,7 +2148,7 @@ def test_generate_version_template_content_already_ends_with_newline(
     # Mock open to track what is written
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
 
-    cache_data = {
+    cache_data: JsonObject = {
         "languages": {
             "python": {
                 "latest": "3.11.0",

--- a/tests/version/core/test_base.py
+++ b/tests/version/core/test_base.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple, cast
+from unittest.mock import Mock
 
 import pytest
 import requests
@@ -6,14 +7,14 @@ from pytest_mock import MockerFixture
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
 from json2vars_setter.version.core.exceptions import GitHubAPIError, ParseError
-from json2vars_setter.version.core.utils import ReleaseInfo
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
 
 
 # Mocking ReleaseInfo
 class MockReleaseInfo:
     """Mock for ReleaseInfo - to avoid clean_version"""
 
-    def __init__(self, version: str, prerelease: bool = False):
+    def __init__(self, version: str, prerelease: bool = False) -> None:
         self.version = version
         self.prerelease = prerelease
 
@@ -23,18 +24,18 @@ class ConcreteVersionFetcher(BaseVersionFetcher):
 
     def __init__(
         self, github_owner: str = "test-owner", github_repo: str = "test-repo"
-    ):
+    ) -> None:
         super().__init__(github_owner, github_repo)
 
-    def _is_stable_tag(self, tag: Dict[str, Any]) -> bool:
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
         """Simple implementation for testing"""
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
         # Assume tags without "alpha", "beta", "rc" are stable
         return not any(x in name.lower() for x in ["alpha", "beta", "rc", "dev", "pre"])
 
-    def _parse_version_from_tag(self, tag: Dict[str, Any]) -> ReleaseInfo:
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
         """Simple implementation for testing"""
-        name = tag.get("name", "")
+        name = str(tag.get("name", ""))
         if not name:
             raise ParseError("Tag name is empty")
         # Check if it's a pre-release (simplified logic)
@@ -169,15 +170,19 @@ def test_get_github_tags_empty_response(mocker: MockerFixture) -> None:
 def test_get_github_tags_pagination(mocker: MockerFixture) -> None:
     """Test GitHub tag fetching with pagination"""
     # Create two pages of responses
-    page1 = [{"name": f"v1.{i}.0"} for i in range(10, 0, -1)]  # v1.10.0 to v1.1.0
-    page2 = [{"name": f"v0.{i}.0"} for i in range(10, 0, -1)]  # v0.10.0 to v0.1.0
+    page1: List[JsonObject] = [
+        {"name": f"v1.{i}.0"} for i in range(10, 0, -1)
+    ]  # v1.10.0 to v1.1.0
+    page2: List[JsonObject] = [
+        {"name": f"v0.{i}.0"} for i in range(10, 0, -1)
+    ]  # v0.10.0 to v0.1.0
 
     # Set up the mock to return different responses for different pages
-    def mock_get_side_effect(*args: Any, **kwargs: Any) -> Any:
-        params = kwargs.get("params", {})
+    def mock_get_side_effect(*args: object, **kwargs: object) -> Mock:
+        params = cast(JsonObject, kwargs.get("params", {}))
         page = params.get("page", 1)
 
-        mock_resp = mocker.Mock()
+        mock_resp: Mock = mocker.Mock()
         mock_resp.raise_for_status.return_value = None
 
         if page == 1:
@@ -189,7 +194,7 @@ def test_get_github_tags_pagination(mocker: MockerFixture) -> None:
 
     # Override the implementation directly
     class TestVersionFetcher(ConcreteVersionFetcher):
-        def _get_github_tags(self, count: Optional[int] = None) -> List[Dict[str, Any]]:
+        def _get_github_tags(self, count: Optional[int] = None) -> List[JsonObject]:
             """Override implementation for testing"""
             all_tags = page1.copy()  # Page 1
             all_tags.extend(page2)  # Page 2
@@ -275,7 +280,7 @@ def test_fetch_versions_basic_flow(mocker: MockerFixture) -> None:
     assert version_info.stable == expected_version
     assert len(version_info.recent_releases) > 0
     assert "source" in version_info.details
-    assert "github:test-owner/test-repo" in version_info.details["source"]
+    assert "github:test-owner/test-repo" in cast(str, version_info.details["source"])
 
 
 def test_fetch_versions_no_tags(mocker: MockerFixture) -> None:
@@ -341,7 +346,7 @@ def test_fetch_versions_all_parse_errors(mocker: MockerFixture) -> None:
     assert version_info.latest is None
     assert version_info.stable is None
     assert "error" in version_info.details
-    assert "Failed to parse any releases" in version_info.details["error"]
+    assert "Failed to parse any releases" in cast(str, version_info.details["error"])
 
 
 def test_fetch_versions_exception(mocker: MockerFixture) -> None:
@@ -361,7 +366,7 @@ def test_fetch_versions_exception(mocker: MockerFixture) -> None:
     assert version_info.latest is None
     assert version_info.stable is None
     assert "error" in version_info.details
-    assert "Unexpected error" in version_info.details["error"]
+    assert "Unexpected error" in cast(str, version_info.details["error"])
     assert version_info.details["error_type"] == "Exception"
 
 

--- a/tests/version/core/test_utils.py
+++ b/tests/version/core/test_utils.py
@@ -1,11 +1,12 @@
 import logging
-from typing import Any, Dict
+import operator
 
 import pytest
 import requests
 from pytest_mock import MockFixture
 
 from json2vars_setter.version.core.utils import (
+    JsonObject,
     ReleaseInfo,
     VersionInfo,
     check_github_api,
@@ -75,7 +76,7 @@ def test_version_info_with_recent_releases() -> None:
 
 def test_version_info_with_details() -> None:
     """Test VersionInfo with details dictionary"""
-    details = {
+    details: JsonObject = {
         "source": "github:test/repo",
         "fetch_time": "2023-01-01T12:00:00",
         "additional_info": "test data",
@@ -109,13 +110,13 @@ def test_release_info_comparison() -> None:
     release1 = ReleaseInfo(version="1.0.0", prerelease=False)
     release2 = ReleaseInfo(version="1.1.0", prerelease=False)
     with pytest.raises(TypeError):
-        release1 < release2
+        operator.lt(release1, release2)
     with pytest.raises(TypeError):
-        release1 > release2
+        operator.gt(release1, release2)
     with pytest.raises(TypeError):
-        release1 <= release2
+        operator.le(release1, release2)
     with pytest.raises(TypeError):
-        release1 >= release2
+        operator.ge(release1, release2)
     assert release1 == ReleaseInfo(version="1.0.0", prerelease=False)
     assert release1 != release2
 
@@ -329,11 +330,11 @@ def test_check_github_api_with_complex_filter(
     ]
     mock_session.get.return_value = mock_response
 
-    def complex_filter(tag: Dict[str, Any]) -> bool:
+    def complex_filter(tag: JsonObject) -> bool:
         """
         Filter to keep only stable (non-beta/alpha) tags
         """
-        return not any(pre in tag["name"] for pre in ["-beta", "-alpha"])
+        return not any(pre in str(tag["name"]) for pre in ["-beta", "-alpha"])
 
     check_github_api(
         mock_session, "test-owner", "test-repo", count=2, filter_func=complex_filter
@@ -388,8 +389,8 @@ def test_check_github_api_with_filter(mocker: MockFixture) -> None:
     mock_response.json.return_value = [{"name": "v1.0.0"}, {"name": "v2.0.0-beta"}]
     mock_session.get.return_value = mock_response
 
-    def filter_func(tag: Dict[str, Any]) -> bool:
-        return "beta" not in tag["name"]
+    def filter_func(tag: JsonObject) -> bool:
+        return "beta" not in str(tag["name"])
 
     check_github_api(
         mock_session, "test-owner", "test-repo", count=2, filter_func=filter_func

--- a/tests/version/fetchers/test_go.py
+++ b/tests/version/fetchers/test_go.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import List, cast
 
 import pytest
 import pytest_mock
@@ -6,7 +6,7 @@ import requests
 from _pytest.capture import CaptureFixture
 
 from json2vars_setter.version.core.exceptions import ParseError
-from json2vars_setter.version.core.utils import ReleaseInfo
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
 from json2vars_setter.version.fetchers.go import GoVersionFetcher, check_api
 
 
@@ -26,12 +26,12 @@ def test_init(go_fetcher: GoVersionFetcher) -> None:
 
 def test_is_stable_tag(go_fetcher: GoVersionFetcher) -> None:
     """Test _is_stable_tag method with various tag scenarios."""
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "go1.22.1"},
         {"name": "go1.21.0"},
         {"name": "go1.20.3"},
     ]
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "go1.22.1-rc1"},
         {"name": "go1.21.0-alpha.1"},
         {"name": "go1.20.3-beta.2"},
@@ -51,7 +51,7 @@ def test_is_stable_tag(go_fetcher: GoVersionFetcher) -> None:
 
 def test_parse_version_from_tag(go_fetcher: GoVersionFetcher) -> None:
     """Test _parse_version_from_tag method."""
-    valid_tag: Dict[str, Any] = {
+    valid_tag: JsonObject = {
         "name": "go1.22.1",
         "commit": {"sha": "abc123"},
         "tarball_url": "https://example.com/tarball",
@@ -62,7 +62,7 @@ def test_parse_version_from_tag(go_fetcher: GoVersionFetcher) -> None:
     assert release_info.prerelease is False
     assert release_info.release_date is None
     assert release_info.additional_info["tag_name"] == "go1.22.1"
-    assert release_info.additional_info["commit"]["sha"] == "abc123"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
     assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
     assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
 

--- a/tests/version/fetchers/test_nodejs.py
+++ b/tests/version/fetchers/test_nodejs.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 import pytest
 import pytest_mock
 import requests
 
 from json2vars_setter.version.core.exceptions import ParseError
-from json2vars_setter.version.core.utils import ReleaseInfo
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
 from json2vars_setter.version.fetchers.nodejs import (
     NodejsVersionFetcher,
     nodejs_filter_func,
@@ -28,12 +28,12 @@ def test_init(nodejs_fetcher: NodejsVersionFetcher) -> None:
 
 def test_is_stable_tag(nodejs_fetcher: NodejsVersionFetcher) -> None:
     """Test _is_stable_tag method with various tag scenarios."""
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "v18.20.0"},
         {"name": "v20.11.1"},
         {"name": "v22.0.0"},
     ]
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "v18.20.0-rc.1"},
         {"name": "v20.11.1-alpha.1"},
         {"name": "v22.0.0-beta.1"},
@@ -54,7 +54,7 @@ def test_is_stable_tag(nodejs_fetcher: NodejsVersionFetcher) -> None:
 
 def test_parse_version_from_tag(nodejs_fetcher: NodejsVersionFetcher) -> None:
     """Test _parse_version_from_tag method."""
-    valid_tag: Dict[str, Any] = {
+    valid_tag: JsonObject = {
         "name": "v18.20.0",
         "commit": {"sha": "abc123"},
         "tarball_url": "https://example.com/tarball",
@@ -65,7 +65,7 @@ def test_parse_version_from_tag(nodejs_fetcher: NodejsVersionFetcher) -> None:
     assert release_info.prerelease is False
     assert release_info.release_date is None
     assert release_info.additional_info["tag_name"] == "v18.20.0"
-    assert release_info.additional_info["commit"]["sha"] == "abc123"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
     assert release_info.additional_info["is_lts"] is False
     assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
     assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
@@ -83,7 +83,7 @@ def test_get_additional_info(
         "_fetch_nodejs_lts_info",
         return_value={"18.20.0": True},
     )
-    info: Dict[str, Any] = nodejs_fetcher._get_additional_info()
+    info: JsonObject = nodejs_fetcher._get_additional_info()
     assert info == {"lts_info": {"18.20.0": True}}
 
 
@@ -117,7 +117,7 @@ def test_get_stability_criteria_no_lts_fetch_tag(
         ReleaseInfo(version="23.0.0", additional_info={"tag_name": "v23.0.0"}),
         ReleaseInfo(version="21.0.0", additional_info={"tag_name": "v21.0.0"}),
     ]
-    mock_tag: Dict[str, Any] = {
+    mock_tag: JsonObject = {
         "name": "v22.9.0",
         "commit": {"sha": "xyz789"},
         "tarball_url": "https://example.com/tarball",
@@ -297,7 +297,7 @@ def test_get_specific_tag_success(
         "get",
         side_effect=[mock_ref_response, mock_tag_response, mock_commit_response],
     )
-    tag: Optional[Dict[str, Any]] = nodejs_fetcher._get_specific_tag("v22.0.0")
+    tag: Optional[JsonObject] = nodejs_fetcher._get_specific_tag("v22.0.0")
     assert tag == {"name": "v22.0.0", "commit": {"sha": "abc123"}}
 
 
@@ -310,7 +310,7 @@ def test_get_specific_tag_failure(
         "get",
         side_effect=requests.exceptions.RequestException("API Error"),
     )
-    tag: Optional[Dict[str, Any]] = nodejs_fetcher._get_specific_tag("v22.0.0")
+    tag: Optional[JsonObject] = nodejs_fetcher._get_specific_tag("v22.0.0")
     assert tag is None
     (
         nodejs_fetcher.logger.warning.assert_called_once_with(  # type: ignore[attr-defined]
@@ -330,7 +330,7 @@ def test_get_specific_tag_no_tag_url(
         "get",
         return_value=mock_ref_response,
     )
-    tag: Optional[Dict[str, Any]] = nodejs_fetcher._get_specific_tag("v22.0.0")
+    tag: Optional[JsonObject] = nodejs_fetcher._get_specific_tag("v22.0.0")
     assert tag is None
     # No warning expected since this is a silent return
 
@@ -348,7 +348,7 @@ def test_get_specific_tag_no_commit_url(
         "get",
         side_effect=[mock_ref_response, mock_tag_response],
     )
-    tag: Optional[Dict[str, Any]] = nodejs_fetcher._get_specific_tag("v22.0.0")
+    tag: Optional[JsonObject] = nodejs_fetcher._get_specific_tag("v22.0.0")
     assert tag is None
     # No warning expected since this is a silent return
 
@@ -435,11 +435,11 @@ def test_get_stability_criteria_lts_fetch_none(
 
 def test_nodejs_filter_func() -> None:
     """Test nodejs_filter_func with various tag scenarios."""
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "v18.20.0"},
         {"name": "v20.11.1"},
     ]
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "v18.20.0-rc.1"},
         {"name": "v20.11.1-alpha.1"},
         {"name": ""},  # Invalid format

--- a/tests/version/fetchers/test_python.py
+++ b/tests/version/fetchers/test_python.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, List
+from typing import List, cast
 
 import pytest
 import pytest_mock
 
 from json2vars_setter.version.core.exceptions import ParseError
-from json2vars_setter.version.core.utils import ReleaseInfo
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
 from json2vars_setter.version.fetchers.python import (
     PythonVersionFetcher,
     python_filter_func,
@@ -20,14 +20,14 @@ def python_fetcher() -> PythonVersionFetcher:
 def test_is_stable_tag(python_fetcher: PythonVersionFetcher) -> None:
     """Test _is_stable_tag method with various tag scenarios"""
     # Stable version tags
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "v3.9.0"},
         {"name": "v3.10.5"},
         {"name": "v4.0.0"},
     ]
 
     # Unstable version tags
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "v3.9.0rc1"},
         {"name": "v3.10.5b2"},
         {"name": "v4.0.0a1"},
@@ -47,7 +47,7 @@ def test_is_stable_tag(python_fetcher: PythonVersionFetcher) -> None:
 def test_parse_version_from_tag(python_fetcher: PythonVersionFetcher) -> None:
     """Test _parse_version_from_tag method"""
     # Valid tag
-    valid_tag: Dict[str, Any] = {
+    valid_tag: JsonObject = {
         "name": "v3.9.2",
         "commit": {"sha": "abc123"},
         "tarball_url": "https://example.com/tarball",
@@ -59,7 +59,7 @@ def test_parse_version_from_tag(python_fetcher: PythonVersionFetcher) -> None:
     assert release_info.version == "3.9.2"
     assert release_info.prerelease is False
     assert release_info.additional_info["tag_name"] == "v3.9.2"
-    assert release_info.additional_info["commit"]["sha"] == "abc123"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
     assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
     assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
 
@@ -98,14 +98,14 @@ def test_get_stability_criteria(python_fetcher: PythonVersionFetcher) -> None:
 def test_python_filter_func() -> None:
     """Test python_filter_func with various tag names"""
     # Stable tags
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "v3.9.0"},
         {"name": "v4.0.1"},
         {"name": "v3.10.5"},
     ]
 
     # Unstable tags
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "v3.9.0rc1"},
         {"name": "v3.10.5b2"},
         {"name": "v4.0.0a1"},
@@ -133,7 +133,7 @@ def test_fetch_versions_integration(
     Note: This is an integration-style test that mocks the GitHub API calls
     """
     # Prepare mock tags
-    mock_tags: List[Dict[str, Any]] = [
+    mock_tags: List[JsonObject] = [
         {
             "name": "v3.12.0",
             "commit": {"sha": "abc123"},

--- a/tests/version/fetchers/test_ruby.py
+++ b/tests/version/fetchers/test_ruby.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, List
+from typing import List, cast
 
 import pytest
 import pytest_mock
 
 from json2vars_setter.version.core.exceptions import ParseError
-from json2vars_setter.version.core.utils import ReleaseInfo
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
 from json2vars_setter.version.fetchers.ruby import RubyVersionFetcher, ruby_filter_func
 
 
@@ -17,14 +17,14 @@ def ruby_fetcher() -> RubyVersionFetcher:
 def test_is_stable_tag(ruby_fetcher: RubyVersionFetcher) -> None:
     """Test _is_stable_tag method with various tag scenarios"""
     # Stable version tags
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "v3_9_0"},
         {"name": "v3_10_5"},
         {"name": "v4_0_0"},
     ]
 
     # Unstable version tags
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "v3_9_0rc1"},
         {"name": "v3_10_5b2"},
         {"name": "v4_0_0a1"},
@@ -47,7 +47,7 @@ def test_is_stable_tag(ruby_fetcher: RubyVersionFetcher) -> None:
 def test_parse_version_from_tag(ruby_fetcher: RubyVersionFetcher) -> None:
     """Test _parse_version_from_tag method"""
     # Valid tag
-    valid_tag: Dict[str, Any] = {
+    valid_tag: JsonObject = {
         "name": "v3_9_2",
         "commit": {"sha": "abc123"},
         "tarball_url": "https://example.com/tarball",
@@ -59,7 +59,7 @@ def test_parse_version_from_tag(ruby_fetcher: RubyVersionFetcher) -> None:
     assert release_info.version == "3.9.2"
     assert release_info.prerelease is False
     assert release_info.additional_info["tag_name"] == "v3_9_2"
-    assert release_info.additional_info["commit"]["sha"] == "abc123"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
     assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
     assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
 
@@ -98,14 +98,14 @@ def test_get_stability_criteria(ruby_fetcher: RubyVersionFetcher) -> None:
 def test_ruby_filter_func() -> None:
     """Test ruby_filter_func with various tag names"""
     # Stable tags
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "v3_9_0"},
         {"name": "v4_0_1"},
         {"name": "v3_10_5"},
     ]
 
     # Unstable tags
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "v3_9_0rc1"},
         {"name": "v3_10_5b2"},
         {"name": "v4_0_0a1"},
@@ -134,7 +134,7 @@ def test_fetch_versions_integration(
     Test fetch_versions method with mocked API calls
     """
     # Prepare mock tags
-    mock_tags: List[Dict[str, Any]] = [
+    mock_tags: List[JsonObject] = [
         {
             "name": "v3_12_0",
             "commit": {"sha": "abc123"},

--- a/tests/version/fetchers/test_rust.py
+++ b/tests/version/fetchers/test_rust.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict, List
+from typing import List, cast
 
 import pytest
 import pytest_mock
 import requests
 
 from json2vars_setter.version.core.exceptions import ParseError
-from json2vars_setter.version.core.utils import ReleaseInfo
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
 from json2vars_setter.version.fetchers.rust import RustVersionFetcher, rust_filter_func
 
 
@@ -25,12 +25,12 @@ def test_init(rust_fetcher: RustVersionFetcher) -> None:
 
 def test_is_stable_tag(rust_fetcher: RustVersionFetcher) -> None:
     """Test _is_stable_tag method with various tag scenarios."""
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "1.75.0"},
         {"name": "1.74.1"},
         {"name": "1.73.0"},
     ]
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "1.75.0-beta.1"},
         {"name": "1.74.1-alpha.2"},
         {"name": "1.73.0-rc.1"},
@@ -49,7 +49,7 @@ def test_is_stable_tag(rust_fetcher: RustVersionFetcher) -> None:
 
 def test_parse_version_from_tag(rust_fetcher: RustVersionFetcher) -> None:
     """Test _parse_version_from_tag method."""
-    valid_tag: Dict[str, Any] = {
+    valid_tag: JsonObject = {
         "name": "1.75.0",
         "commit": {"sha": "abc123"},
         "tarball_url": "https://example.com/tarball",
@@ -60,7 +60,7 @@ def test_parse_version_from_tag(rust_fetcher: RustVersionFetcher) -> None:
     assert release_info.prerelease is False
     assert release_info.release_date is None
     assert release_info.additional_info["tag_name"] == "1.75.0"
-    assert release_info.additional_info["commit"]["sha"] == "abc123"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
     assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
     assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
 
@@ -77,7 +77,7 @@ def test_get_additional_info_success(
         "_fetch_rust_channel_info",
         return_value={"stable_channel_available": True},
     )
-    info: Dict[str, Any] = rust_fetcher._get_additional_info()
+    info: JsonObject = rust_fetcher._get_additional_info()
     assert info == {"channel_info": {"stable_channel_available": True}}
 
 
@@ -89,7 +89,7 @@ def test_fetch_rust_channel_info_success(
     mock_response.raise_for_status.return_value = None  # Successful request
     mocker.patch.object(rust_fetcher.session, "get", return_value=mock_response)
 
-    channel_info: Dict[str, Any] = rust_fetcher._fetch_rust_channel_info()
+    channel_info: JsonObject = rust_fetcher._fetch_rust_channel_info()
     assert channel_info == {"stable_channel_available": True}
 
 
@@ -103,7 +103,7 @@ def test_fetch_rust_channel_info_failure(
         side_effect=requests.exceptions.RequestException("API Error"),
     )
 
-    channel_info: Dict[str, Any] = rust_fetcher._fetch_rust_channel_info()
+    channel_info: JsonObject = rust_fetcher._fetch_rust_channel_info()
     assert channel_info == {"stable_channel_available": False}
     (
         rust_fetcher.logger.warning.assert_called_once_with(  # type: ignore[attr-defined]
@@ -138,11 +138,11 @@ def test_get_stability_criteria_no_releases(rust_fetcher: RustVersionFetcher) ->
 
 def test_rust_filter_func() -> None:
     """Test rust_filter_func with various tag scenarios."""
-    stable_tags: List[Dict[str, Any]] = [
+    stable_tags: List[JsonObject] = [
         {"name": "1.75.0"},
         {"name": "1.74.1"},
     ]
-    unstable_tags: List[Dict[str, Any]] = [
+    unstable_tags: List[JsonObject] = [
         {"name": "1.75.0-beta.1"},
         {"name": "1.74.1-alpha.2"},
         {"name": "1.73.0-rc.1"},

--- a/uv.lock
+++ b/uv.lock
@@ -424,6 +424,7 @@ dev = [
     { name = "pytest-testmon" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "types-requests" },
     { name = "zensical" },
 ]
 
@@ -444,6 +445,7 @@ dev = [
     { name = "pytest-testmon", specifier = ">=2.1.4,<3.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
     { name = "ruff", specifier = ">=0.15.10,<0.16.0" },
+    { name = "types-requests", specifier = ">=2.32.0,<3.0.0" },
     { name = "zensical", specifier = ">=0.0.32,<0.0.44" },
 ]
 
@@ -1100,6 +1102,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/d3/90c1ee19209cb59f6ad185883fd4ccfcf72f8f0bfd549d5a8b70474611d0/typer-0.26.4.tar.gz", hash = "sha256:25b128964de66c5ea36d5ac82adc579e5e113509b17469edf9f5a4a1864ff2a9", size = 201191, upload-time = "2026-05-30T17:05:04.213Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl", hash = "sha256:11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6", size = 122436, upload-time = "2026-05-30T17:05:05.812Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

mypy と ruff のルールを厳格化し、`typing.Any` 型の使用を**ソースコードとテストコードの両方で禁止**しました。

## 変更内容

### 設定
- **mypy**: `strict = true` + `disallow_any_explicit = true`（`typing.Any` を全面禁止）+ `warn_unreachable`
- **ruff**: `select = ["E", "F", "I", "B", "ANN", "RUF"]`（`ANN401` が注釈内の `Any` を禁止）
- **`.pre-commit-config.yaml`**: 隔離環境で動く mypy フックに `typer` / `pytest` / `pytest-mock` を追加。`strict` で有効化された `disallow_untyped_decorators` が typer/pytest デコレータを解決できるようにし、pre-commit と `uv run mypy` の結果を一致させた

### ソースコード
- `cli.py` / `version/core/base.py`: `raise ... from err`（B904）、`__init__ -> None`（ANN204）
- fetchers (`go`/`python`/`ruby`): 未使用アンパック変数を `_` 付きに（RUF059）

### テストコード（本PRの主目的）
ソースと同じ `JsonObject = Dict[str, object]` + 絞り込みパターンを適用:
- `Any` / `Dict[str, Any]` → `JsonObject` / `object` / 具体型に置換
- `ReleaseInfo` / `VersionInfo` の import を `core.utils` 経由に修正（re-export エラー解消）
- JSON インデックスアクセスを `cast` / `str(...)` で絞り込み（`test_version_cache.py` に型付きヘルパーを追加）
- pytest フィクスチャに型注釈、レガシー `tmpdir` → `tmp_path: Path` に移行
- B015 / RUF005 / RUF059 修正

## 検証

| チェック | 結果 |
|---|---|
| `mypy --config-file=pyproject.toml` | ✅ 37ファイル 問題なし |
| `ruff check` / `ruff format --check` | ✅ 合格 |
| pre-commit `ruff` / `ruff-format` / `mypy` | ✅ 合格 |
| `pytest` + カバレッジ | ✅ 206件 全パス、カバレッジ100% |

> [!NOTE]
> ローカルでは `shellcheck` / `actionlint` / `markdownlint` の pre-commit フックは Windows の OpenSSL Applink 制約により実行不可（gitleaks と同様の既知の環境制約）。今回の変更対象ファイルには無関係で、CI では正常に動作します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)