### PR TITLE
:bug: Bump semantic-release workflow Node to 22

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          # semantic-release@25 requires Node ^22.14.0 || >= 24.10.0
+          node-version: 22
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## 概要

`semantic-release.yml` のリリース実行が、Node バージョン不一致で失敗していたため修正します。

## エラー内容

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.
```

`semantic-release@25.0.3` は Node `^22.14.0 || >= 24.10.0` を要求しますが、ワークフローは `node-version: 20` を指定していました。

## 修正

- `actions/setup-node` の `node-version: 20` → `22`

リリースのバージョン判定（gitmoji ベース）には影響しません。マージ後にリリースワークフローを再実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)