### PR TITLE
:sparkles: Add PHP version support

### DIFF
--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -23,7 +23,14 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        uses: 7rikazhexde/json2vars-setter@v1.3.0
+        # Use the in-repo action so this workflow tests the current code. A new
+        # language's `versions_<lang>` output does not exist in the published tag
+        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
+        # until then; `./` keeps the example workflow green from the first PR.
+        # TODO(after the release that adds PHP): switch to the pinned tag
+        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
+        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
+        uses: ./
         with:
           json-file: examples/php/php_project_matrix.json
 

--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -1,0 +1,158 @@
+name: PHP Test
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'examples/php/**'
+      - '.github/workflows/php_test.yml'
+
+jobs:
+  set_variables:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.json2vars.outputs.os }}
+      versions_php: ${{ steps.json2vars.outputs.versions_php }}
+      ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set variables from JSON
+        id: json2vars
+        uses: 7rikazhexde/json2vars-setter@v1.3.0
+        with:
+          json-file: examples/php/php_project_matrix.json
+
+      - name: Debug output values
+        run: |
+          echo "os: ${{ steps.json2vars.outputs.os }}"
+          echo "os[0]: ${{ fromJson(steps.json2vars.outputs.os)[0] }}"
+          echo "os[1]: ${{ fromJson(steps.json2vars.outputs.os)[1] }}"
+          echo "os[2]: ${{ fromJson(steps.json2vars.outputs.os)[2] }}"
+          echo "versions_php: ${{ steps.json2vars.outputs.versions_php }}"
+          echo "versions_php[0]: ${{ fromJson(steps.json2vars.outputs.versions_php)[0] }}"
+          echo "versions_php[1]: ${{ fromJson(steps.json2vars.outputs.versions_php)[1] }}"
+          echo "versions_php[2]: ${{ fromJson(steps.json2vars.outputs.versions_php)[2] }}"
+          echo "ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}"
+
+  run_tests:
+    needs: set_variables
+    strategy:
+      # Run every matrix combination even if one fails so the aggregated job
+      # result reflects the status of the whole matrix (used by the badge).
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.set_variables.outputs.os) }}
+        php-version: ${{ fromJson(needs.set_variables.outputs.versions_php) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer
+
+      - name: Set timezone
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
+        with:
+          timezoneLinux: "Asia/Tokyo"
+          timezoneMacos: "Asia/Tokyo"
+          timezoneWindows: "Tokyo Standard Time"
+
+      - name: Display PHP version
+        run: |
+          php --version
+          composer --version
+
+      - name: Show matrix
+        shell: bash
+        run: |
+          # For non-list case
+          ghpages_branch="${{ needs.set_variables.outputs.ghpages_branch }}"
+
+          # For list case, explicitly enclose the list in "" to make it a string. (Note that it is not ''.)
+          os='${{ needs.set_variables.outputs.os }}'
+          versions_php='${{ needs.set_variables.outputs.versions_php }}'
+
+          # For list index case
+          os_0="${{ fromJson(needs.set_variables.outputs.os)[0] }}"
+          os_1="${{ fromJson(needs.set_variables.outputs.os)[1] }}"
+          os_2="${{ fromJson(needs.set_variables.outputs.os)[2] }}"
+
+          versions_php_0="${{ fromJson(needs.set_variables.outputs.versions_php)[0] }}"
+          versions_php_1="${{ fromJson(needs.set_variables.outputs.versions_php)[1] }}"
+          versions_php_2="${{ fromJson(needs.set_variables.outputs.versions_php)[2] }}"
+
+          echo "os: ${os}"
+          echo "os_0: ${os_0}"
+          echo "os_1: ${os_1}"
+          echo "os_2: ${os_2}"
+          echo "versions_php: ${versions_php}"
+          echo "versions_php_0: ${versions_php_0}"
+          echo "versions_php_1: ${versions_php_1}"
+          echo "versions_php_2: ${versions_php_2}"
+          echo "ghpages_branch: ${ghpages_branch}"
+
+          # For loop case
+          os_list=$(echo "${os}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          php_versions_list=$(echo "${versions_php}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+
+          for current_os in ${os_list}; do
+            for version in ${php_versions_list}; do
+              echo "Current OS: ${current_os}, Current PHP Version: ${version}"
+            done
+          done
+
+      - name: Run tests
+        id: php_test
+        working-directory: ./examples/php
+        shell: bash
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
+        run: |
+          composer install --no-interaction --no-progress
+          composer test
+
+  update_badge:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Determine status and color
+        id: status
+        shell: bash
+        run: |
+          # needs.run_tests.result aggregates every matrix combination:
+          # 'success' only when all passed, 'failure' if any leg failed.
+          case "${{ needs.run_tests.result }}" in
+            success)   status=passing;   color=2ea44f ;;
+            failure)   status=failing;   color=cf222e ;;
+            cancelled) status=cancelled; color=808080 ;;
+            skipped)   status=skipped;   color=808080 ;;
+            *)         status=pending;   color=dbab09 ;;
+          esac
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
+
+      - name: Create badge
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: a9bc428c9f5a2f998bd7307038e557e1
+          filename: php-test-badge.json
+          label: PHP Test
+          message: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          labelColor: "24292f"
+          style: "flat"
+          namedLogo: "github"
+          logoColor: "white"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,10 +122,17 @@ or the addition is incomplete:
    the new workflow. Also update any "supported languages" prose (README intro,
    `docs/features/dynamic-update.md`, `docs/reference/options.md`, this file's
    Project Overview + fetcher list).
-9. **Release ordering caveat** — the new `<lang>_test.yml` references the action by its
-   published tag (`@vX.Y.Z`), so `versions_<lang>` is only available **after** the
-   release that includes the new language. The workflow stays red between merge and the
-   next release; the release's `sync-version-refs.sh` bumps the tag and it goes green.
+9. **Release ordering (two-phase action reference)** — a new language's
+   `versions_<lang>` output does not exist in the published tag until the release that
+   adds it, so a tag ref (`@vX.Y.Z`) in `<lang>_test.yml` would fail on the introducing
+   PR. Handle this in two phases:
+   - **In the introducing PR:** point `<lang>_test.yml` at the in-repo action with
+     `uses: ./` so the workflow tests the PR's own code and is green from the start.
+   - **After the release that adds the language:** switch it to the pinned tag
+     `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match every other `*_test.yml` and
+     the Versioning Rule. From then on `sync-version-refs.sh` keeps it pinned to the
+     latest release. **This swap is a required follow-up** — track it so the example
+     workflow does not stay on `./`.
 
 ## Code Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, and Rust. The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
+json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, and PHP. The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
 
 ## Common Commands
 
@@ -79,7 +79,7 @@ A pluggable architecture for fetching language versions from GitHub:
 - **`version/core/base.py`** — `BaseVersionFetcher` abstract class handles GitHub API pagination, authentication (via `GITHUB_TOKEN`), and defines the interface (`_is_stable_tag()`, `_parse_version_from_tag()`)
 - **`version/core/exceptions.py`** — Exception hierarchy: `VersionFetchError` → `GitHubAPIError`, `ParseError`, `ValidationError`
 - **`version/core/utils.py`** — Shared data classes (`VersionInfo`, `ReleaseInfo`) and helpers
-- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`), each parsing tags from the respective GitHub repository
+- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`), each parsing tags from the respective GitHub repository
 
 ### Entry Points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,46 @@ A pluggable architecture for fetching language versions from GitHub:
 - **CLI**: `json2vars_setter/cli.py` — Typer app exposed as `json2vars` via `[project.scripts]`; commands call each feature's `main()` **in-process** (no subprocess)
 - **Direct module execution**: `python -m json2vars_setter.features.<module>`
 
+## Adding a New Language (complete checklist)
+
+Adding a supported language touches **code, the action contract, tests, an example
+project, a CI workflow, status badges, and docs**. All of the following must be done
+or the addition is incomplete:
+
+1. **Fetcher** — `json2vars_setter/version/fetchers/<lang>.py`: a `BaseVersionFetcher`
+   subclass implementing `_is_stable_tag` / `_parse_version_from_tag` (and usually
+   `_get_stability_criteria`) plus a `<lang>_filter_func` and the `__main__` block,
+   modeled on the closest existing fetcher (e.g. `ruby.py` / `go.py`).
+2. **Registry** — register the fetcher in `json2vars_setter/version/registry.py`
+   (`LANGUAGE_FETCHERS`).
+3. **Matrix update CLI** — `json2vars_setter/features/matrix_update.py`: add the
+   `--<lang>` argument, the `args.<lang> = args.all` line in the `--all` block, and
+   the `if args.<lang>: language_strategies["<lang>"] = ...` wiring.
+4. **Action contract** — `action.yml`: add the `<lang>-strategy` input, the
+   `versions_<lang>` output, the strategy-arg building block, and the summary `echo`.
+5. **Tests (keep 100% coverage)** — `tests/version/fetchers/test_<lang>.py`, plus add
+   the language to `tests/version/test_registry.py` and the `--all` / individual-flag
+   assertions in `tests/features/test_matrix_update.py`.
+6. **Example project** — `examples/<lang>/`: a small JSON-parser project with source,
+   tests, `<lang>_project_matrix.json`, build config, and `README.md` (mirror
+   `examples/ruby/`). The matrix versions must be in the format the language's
+   `setup-*` action accepts.
+7. **Example CI workflow** — `.github/workflows/<lang>_test.yml` (mirror
+   `ruby_test.yml`): `set_variables` → `run_tests` (matrix) → `update_badge`. The
+   `update_badge` job needs a **dedicated gist** (`<lang>-test-badge.json`, written via
+   `GIST_TOKEN`) — its `gistID` must be created by the repo owner and cannot be
+   generated programmatically.
+8. **Status badges** — add a row to the language table in `README.md` **and** the
+   matching badge in `docs/index.md`, pointing at the new gist
+   (`gist.githubusercontent.com/7rikazhexde/<GIST_ID>/raw/<lang>-test-badge.json`) and
+   the new workflow. Also update any "supported languages" prose (README intro,
+   `docs/features/dynamic-update.md`, `docs/reference/options.md`, this file's
+   Project Overview + fetcher list).
+9. **Release ordering caveat** — the new `<lang>_test.yml` references the action by its
+   published tag (`@vX.Y.Z`), so `versions_<lang>` is only available **after** the
+   release that includes the new language. The workflow stays red between merge and the
+   next release; the release's `sync-version-refs.sh` bumps the tag and it goes green.
+
 ## Code Conventions
 
 - **Commit messages**: Follow [gitmoji](https://gitmoji.dev/) conventions. Releases are automated by **semantic-release-gitmoji**, which reads the gitmoji to pick the next version: `:boom:` → major, `:sparkles:` → minor, and fixes/maintenance (`:bug:`, `:lock:`, `:ambulance:`, `:zap:`, `:wrench:`, `:recycle:`, `:arrow_up:`, …) → patch. Other gitmoji (e.g. `:memo:`, `:art:`, `:white_check_mark:`) don't trigger a release. The full mapping is the `releaseRules` in `.releaserc.json`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, and Rust
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, and PHP
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -38,6 +38,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![Node.js](https://img.shields.io/badge/Node.js-339933?style=flat&logo=node.js&logoColor=white) | [![setup-node](https://img.shields.io/badge/setup--node-339933?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-node-js-environment) | [![Node.js Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/11f46ff9ef47d3362dabe767255b0d9e/raw/nodejs-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/nodejs_test.yml) |
 | ![Go](https://img.shields.io/badge/Go-00ADD8?style=flat&logo=go&logoColor=white) | [![setup-go](https://img.shields.io/badge/setup--go-00ADD8?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-go-environment) | [![Go Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/c334da204406866563668140885d170e/raw/go-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/go_test.yml) |
 | ![Rust](https://img.shields.io/badge/Rust-000000?style=flat&logo=rust&logoColor=white) | [![rust-toolchain](https://img.shields.io/badge/rust--toolchain-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/rustup-toolchain-install) | [![Rust Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5e160d06cfffd42a8f0e4ae6e8e8f025/raw/rust-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/rust_test.yml) |
+| ![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat&logo=php&logoColor=white) | [![setup-php](https://img.shields.io/badge/setup--php-777BB4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-php-action) | [![PHP Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/a9bc428c9f5a2f998bd7307038e557e1/raw/php-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/php_test.yml) |
 
 ## Quick Start
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   rust-strategy:
     description: 'Update strategy for Rust versions (stable, latest, or both)'
     required: false  # Optional
+  php-strategy:
+    description: 'Update strategy for PHP versions (stable, latest, or both)'
+    required: false  # Optional
 
   # Safe Mode
   dry-run:
@@ -126,6 +129,9 @@ outputs:
   versions_rust:
     description: 'List of Rust versions'
     value: ${{ steps.set_outputs.outputs.versions_rust }}
+  versions_php:
+    description: 'List of PHP versions'
+    value: ${{ steps.set_outputs.outputs.versions_php }}
   ghpages_branch:
     description: 'GitHub Pages branch'
     value: ${{ steps.set_outputs.outputs.ghpages_branch }}
@@ -189,6 +195,9 @@ runs:
           fi
           if [[ -n "${{ inputs.rust-strategy }}" ]]; then
             ARGS+=("--rust" "${{ inputs.rust-strategy }}")
+          fi
+          if [[ -n "${{ inputs.php-strategy }}" ]]; then
+            ARGS+=("--php" "${{ inputs.php-strategy }}")
           fi
         fi
 
@@ -308,4 +317,5 @@ runs:
         echo "Node.js Versions: ${{ steps.set_outputs.outputs.versions_nodejs }}"
         echo "Go Versions: ${{ steps.set_outputs.outputs.versions_go }}"
         echo "Rust Versions: ${{ steps.set_outputs.outputs.versions_rust }}"
+        echo "PHP Versions: ${{ steps.set_outputs.outputs.versions_php }}"
         echo "GitHub Pages Branch: ${{ steps.set_outputs.outputs.ghpages_branch }}"

--- a/docs/features/dynamic-update.md
+++ b/docs/features/dynamic-update.md
@@ -192,6 +192,7 @@ The Dynamic Matrix Updater accepts the following inputs:
 | `ruby-strategy` | Strategy for Ruby versions | No | - |
 | `go-strategy` | Strategy for Go versions | No | - |
 | `rust-strategy` | Strategy for Rust versions | No | - |
+| `php-strategy` | Strategy for PHP versions | No | - |
 | `dry-run` | Run without updating the file | No | `'false'` |
 
 ## How It Works
@@ -242,6 +243,7 @@ The Dynamic Matrix Updater currently supports:
 - **Ruby**: Fetches from Ruby releases via GitHub API
 - **Go**: Fetches from Go releases via GitHub API
 - **Rust**: Fetches from Rust releases via GitHub API
+- **PHP**: Fetches from PHP releases via GitHub API
 
 ## Best Practices
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -109,7 +109,7 @@ graph LR
 - **Automated Version Updates**: Keep testing matrices current without manual intervention
 - **Efficient API Usage**: Reduce external API calls by caching version information
 - **Cross-Platform Testing**: Define operating systems and language versions for comprehensive testing
-- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, and Rust in a single configuration
+- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, and PHP in a single configuration
 
 ## Component Integration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, and Rust
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, and PHP
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -25,6 +25,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![Node.js](https://img.shields.io/badge/Node.js-339933?style=flat&logo=node.js&logoColor=white) | [![setup-node](https://img.shields.io/badge/setup--node-339933?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-node-js-environment) | [![Node.js Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/11f46ff9ef47d3362dabe767255b0d9e/raw/nodejs-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/nodejs_test.yml) |
 | ![Go](https://img.shields.io/badge/Go-00ADD8?style=flat&logo=go&logoColor=white) | [![setup-go](https://img.shields.io/badge/setup--go-00ADD8?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-go-environment) | [![Go Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/c334da204406866563668140885d170e/raw/go-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/go_test.yml) |
 | ![Rust](https://img.shields.io/badge/Rust-000000?style=flat&logo=rust&logoColor=white) | [![rust-toolchain](https://img.shields.io/badge/rust--toolchain-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/rustup-toolchain-install) | [![Rust Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5e160d06cfffd42a8f0e4ae6e8e8f025/raw/rust-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/rust_test.yml) |
+| ![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat&logo=php&logoColor=white) | [![setup-php](https://img.shields.io/badge/setup--php-777BB4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-php-action) | [![PHP Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/a9bc428c9f5a2f998bd7307038e557e1/raw/php-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/php_test.yml) |
 
 ## Quick Start
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -21,6 +21,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `ruby-strategy` | Update strategy for Ruby versions | ✗ | - | Same valid values as `update-strategy` |
 | `go-strategy` | Update strategy for Go versions | ✗ | - | Same valid values as `update-strategy` |
 | `rust-strategy` | Update strategy for Rust versions | ✗ | - | Same valid values as `update-strategy` |
+| `php-strategy` | Update strategy for PHP versions | ✗ | - | Same valid values as `update-strategy` |
 | `dry-run` | Run in dry-run mode without updating the JSON file | ✗ | `false` | For testing update strategies |
 
 ### Cache Version Options
@@ -50,6 +51,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `versions_nodejs` | List of Node.js versions | `["16", "18", "20"]` |
 | `versions_go` | List of Go versions | `["1.19", "1.20", "1.21"]` |
 | `versions_rust` | List of Rust versions | `["1.70.0", "1.71.0", "stable"]` |
+| `versions_php` | List of PHP versions | `["8.2.0", "8.3.0", "8.4.0"]` |
 | `ghpages_branch` | GitHub Pages branch name | `"gh-pages"` |
 
 ## Usage Notes

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -1,0 +1,67 @@
+# PHP Example for json2vars-setter
+
+This is a PHP implementation example for parsing JSON configuration files in GitHub Actions matrix testing.
+
+## Requirements
+
+- PHP >= 8.2
+- Composer
+
+## Project Structure
+
+```bash
+.
+├── composer.json             # PHP dependencies and scripts
+├── phpunit.xml               # PHPUnit configuration
+├── php_project_matrix.json   # Matrix definition consumed by json2vars-setter
+├── src/
+│   └── JsonParser.php        # Main implementation
+└── tests/
+    └── JsonParserTest.php    # Test implementation
+```
+
+## Setup
+
+Install dependencies with Composer:
+
+```bash
+cd examples/php
+composer install
+```
+
+## Running
+
+Run the parser directly:
+
+```bash
+composer start
+# or
+php src/JsonParser.php
+```
+
+Run the tests:
+
+```bash
+composer test
+# or
+vendor/bin/phpunit
+```
+
+## Matrix file
+
+`php_project_matrix.json` defines the OS list and PHP versions used by the matrix
+testing workflow. The PHP versions use the `major.minor` form accepted by
+[`shivammathur/setup-php`](https://github.com/marketplace/actions/setup-php-action):
+
+```json
+{
+    "os": ["ubuntu-latest", "windows-latest", "macos-latest"],
+    "versions": {
+        "php": ["8.2", "8.3", "8.4"]
+    },
+    "ghpages_branch": "ghgapes"
+}
+```
+
+The `.github/workflows/php_test.yml` workflow reads this file through
+json2vars-setter and runs the tests across every OS / PHP version combination.

--- a/examples/php/composer.json
+++ b/examples/php/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "json2vars-setter/php-example",
+    "description": "PHP example for json2vars-setter matrix testing",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php": ">=8.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "JsonVarsSetter\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "JsonVarsSetter\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "start": "php src/JsonParser.php"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/examples/php/php_project_matrix.json
+++ b/examples/php/php_project_matrix.json
@@ -1,0 +1,15 @@
+{
+    "os": [
+        "ubuntu-latest",
+        "windows-latest",
+        "macos-latest"
+    ],
+    "versions": {
+        "php": [
+            "8.2",
+            "8.3",
+            "8.4"
+        ]
+    },
+    "ghpages_branch": "ghgapes"
+}

--- a/examples/php/phpunit.xml
+++ b/examples/php/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/examples/php/src/JsonParser.php
+++ b/examples/php/src/JsonParser.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonVarsSetter;
+
+/**
+ * Minimal JSON configuration parser used to demonstrate consuming the
+ * json2vars-setter matrix file in a PHP project.
+ */
+final class JsonParser
+{
+    /**
+     * Parse a JSON configuration file into an associative array.
+     *
+     * @param string $filePath Path to the JSON file.
+     * @param bool   $silent   When true, suppress error output.
+     *
+     * @return array<string, mixed>|null The parsed data, or null on failure.
+     */
+    public static function parseConfig(string $filePath, bool $silent = false): ?array
+    {
+        try {
+            $contents = @file_get_contents($filePath);
+            if ($contents === false) {
+                throw new \RuntimeException("Unable to read file: {$filePath}");
+            }
+
+            /** @var array<string, mixed> $data */
+            $data = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+            return $data;
+        } catch (\Throwable $e) {
+            if (!$silent) {
+                fwrite(STDERR, "Error reading or parsing JSON: {$e->getMessage()}\n");
+            }
+
+            return null;
+        }
+    }
+}
+
+// Allow running the file directly: `php src/JsonParser.php`
+if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === __FILE__) {
+    $configPath = __DIR__ . '/../php_project_matrix.json';
+    $result = JsonParser::parseConfig($configPath);
+    if ($result !== null) {
+        echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), PHP_EOL;
+    }
+}

--- a/examples/php/tests/JsonParserTest.php
+++ b/examples/php/tests/JsonParserTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonVarsSetter\Tests;
+
+use JsonVarsSetter\JsonParser;
+use PHPUnit\Framework\TestCase;
+
+final class JsonParserTest extends TestCase
+{
+    private string $configPath;
+
+    protected function setUp(): void
+    {
+        $this->configPath = __DIR__ . '/../php_project_matrix.json';
+    }
+
+    public function testParsesJsonFile(): void
+    {
+        $result = JsonParser::parseConfig($this->configPath);
+        $this->assertIsArray($result);
+    }
+
+    public function testParsesExpectedValues(): void
+    {
+        $result = JsonParser::parseConfig($this->configPath);
+
+        $this->assertIsArray($result);
+        $this->assertContains('ubuntu-latest', $result['os']);
+        $this->assertContains('windows-latest', $result['os']);
+        $this->assertContains('macos-latest', $result['os']);
+        $this->assertSame(['8.2', '8.3', '8.4'], $result['versions']['php']);
+        $this->assertSame('ghgapes', $result['ghpages_branch']);
+    }
+
+    public function testReturnsNullForMissingFile(): void
+    {
+        $result = JsonParser::parseConfig('non-existent.json', true);
+        $this->assertNull($result);
+    }
+}

--- a/json2vars_setter/features/matrix_update.py
+++ b/json2vars_setter/features/matrix_update.py
@@ -265,6 +265,11 @@ Examples:
         help="Strategy for Rust versions",
     )
     parser.add_argument(
+        "--php",
+        choices=["stable", "latest", "both"],
+        help="Strategy for PHP versions",
+    )
+    parser.add_argument(
         "--all",
         choices=["stable", "latest", "both"],
         help="Apply the same strategy to all languages",
@@ -297,6 +302,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         args.ruby = args.all
         args.go = args.all
         args.rust = args.all
+        args.php = args.all
 
     # Collect language strategies
     language_strategies: Dict[str, str] = {}
@@ -310,6 +316,8 @@ def main(argv: Optional[List[str]] = None) -> None:
         language_strategies["go"] = args.go
     if args.rust:
         language_strategies["rust"] = args.rust
+    if args.php:
+        language_strategies["php"] = args.php
 
     if not language_strategies:
         parser.error("At least one language strategy must be specified")

--- a/json2vars_setter/version/fetchers/php.py
+++ b/json2vars_setter/version/fetchers/php.py
@@ -1,0 +1,196 @@
+import os
+import re
+from typing import List, Tuple, cast
+
+import requests
+
+from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.core.exceptions import ParseError
+from json2vars_setter.version.core.utils import (
+    JsonObject,
+    ReleaseInfo,
+    check_github_api,
+    setup_logging,
+)
+
+# Stable PHP tags look exactly like "php-8.4.1"; pre-releases append a suffix
+# (e.g. "php-8.5.0RC1", "php-8.5.0beta1") and unrelated tags (e.g. "yaf-2.1.0")
+# do not match this pattern.
+_STABLE_TAG_PATTERN = re.compile(r"php-\d+\.\d+\.\d+$")
+
+
+class PhpVersionFetcher(BaseVersionFetcher):
+    """Fetches PHP version information from GitHub"""
+
+    def __init__(self) -> None:
+        """Initialize with PHP's GitHub repository information"""
+        super().__init__("php", "php-src")
+
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
+        """
+        Check if a tag represents a stable PHP release
+
+        Args:
+            tag: Tag information from GitHub API
+
+        Returns:
+            True if the tag represents a stable release, False otherwise
+        """
+        name = str(tag.get("name", ""))
+
+        # PHP uses format "php-X.Y.Z" for stable releases
+        return bool(_STABLE_TAG_PATTERN.fullmatch(name))
+
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
+        """
+        Parse version information from a PHP tag
+
+        Args:
+            tag: Tag information from GitHub API
+
+        Returns:
+            Parsed ReleaseInfo object
+
+        Raises:
+            ParseError: If required version information cannot be parsed
+        """
+        name = str(tag.get("name", ""))
+        if not name:
+            raise ParseError("No tag name found")
+
+        # Clean version string (e.g., "php-8.4.1" -> "8.4.1")
+        version = name.removeprefix("php-")
+
+        # All filtered tags are considered stable
+        prerelease = False
+
+        return ReleaseInfo(
+            version=version,
+            release_date=None,
+            prerelease=prerelease,
+            additional_info={
+                "tag_name": name,
+                "commit": {"sha": cast(JsonObject, tag.get("commit", {})).get("sha")},
+                "tarball_url": tag.get("tarball_url"),
+                "zipball_url": tag.get("zipball_url"),
+            },
+        )
+
+    def _get_stability_criteria(
+        self, releases: List[ReleaseInfo]
+    ) -> Tuple[ReleaseInfo, ReleaseInfo]:
+        """
+        Determine the stable and latest versions of PHP
+
+        In PHP:
+        - latest: The most recent release version
+        - stable: Usually the previous minor version to the latest, or
+          a version that has been stable for a sufficient period
+
+        Args:
+            releases: List of release information
+
+        Returns:
+            Tuple of (latest_release, stable_release)
+        """
+        if not releases:
+            # Raise an exception to explicitly handle the case where no releases are available
+            raise ValueError("No releases available")
+
+        # The latest version is always the first release
+        latest = releases[0]
+
+        # Get and parse the version number
+        latest_version = latest.version
+        match = re.match(r"(\d+)\.(\d+)\.(\d+)", latest_version)
+
+        if match:
+            major, minor, _patch = map(int, match.groups())
+            # Look for the previous minor version
+            prev_minor = minor - 1
+
+            # Search for a release with the previous minor version
+            for release in releases:
+                r_match = re.match(r"(\d+)\.(\d+)\.(\d+)", release.version)
+                if r_match:
+                    r_major, r_minor, _r_patch = map(int, r_match.groups())
+                    if r_major == major and r_minor == prev_minor:
+                        self.logger.info(
+                            f"Using {release.version} as stable vs latest {latest_version}"
+                        )
+                        return latest, release
+
+        # Use the latest version if no suitable stable version is found
+        self.logger.info(
+            f"No suitable stable version found, using latest {latest_version} as stable"
+        )
+        return latest, latest
+
+
+def php_filter_func(tag: JsonObject) -> bool:
+    """Filter function for PHP tags in API checker"""
+    name = str(tag.get("name", ""))
+    return bool(_STABLE_TAG_PATTERN.fullmatch(name))
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Fetch PHP version information")
+    parser.add_argument(
+        "--count", type=int, default=5, help="Number of versions to fetch"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="count", default=0, help="Increase verbosity"
+    )
+    args = parser.parse_args()
+
+    # Set up logging
+    logger = setup_logging(args.verbose)
+
+    # Check API directly if in verbose mode
+    if args.verbose > 0:
+        # Create a session for API checking
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "json2vars-setter",
+            }
+        )
+
+        # Add GitHub token if available
+        github_token = os.environ.get("GITHUB_TOKEN")
+        if github_token:
+            session.headers.update({"Authorization": f"token {github_token}"})
+
+        check_github_api(
+            session=session,
+            github_owner="php",
+            github_repo="php-src",
+            count=args.count,
+            filter_func=php_filter_func,
+        )
+
+    # Display header in verbose mode
+    if args.verbose > 0:
+        print("\n=== Fetching PHP Versions ===")
+
+    # Main processing
+    fetcher = PhpVersionFetcher()
+    versions = fetcher.fetch_versions(recent_count=args.count)
+
+    # Output results
+    print(
+        json.dumps(
+            {
+                "latest": versions.latest,
+                "stable": versions.stable,
+                "recent_releases": [vars(r) for r in versions.recent_releases],
+                "details": versions.details,
+            },
+            indent=2,
+        )
+    )

--- a/json2vars_setter/version/registry.py
+++ b/json2vars_setter/version/registry.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict
 from json2vars_setter.version.core.base import BaseVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
 from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
+from json2vars_setter.version.fetchers.php import PhpVersionFetcher
 from json2vars_setter.version.fetchers.python import PythonVersionFetcher
 from json2vars_setter.version.fetchers.ruby import RubyVersionFetcher
 from json2vars_setter.version.fetchers.rust import RustVersionFetcher
@@ -22,6 +23,7 @@ LANGUAGE_FETCHERS: Dict[str, Callable[[], BaseVersionFetcher]] = {
     "ruby": RubyVersionFetcher,
     "go": GoVersionFetcher,
     "rust": RustVersionFetcher,
+    "php": PhpVersionFetcher,
 }
 
 

--- a/tests/features/test_matrix_update.py
+++ b/tests/features/test_matrix_update.py
@@ -301,6 +301,7 @@ def test_main_function(mocker: MockerFixture) -> None:
             "ruby": "stable",
             "go": "stable",
             "rust": "stable",
+            "php": "stable",
         },
         False,
     )
@@ -314,6 +315,8 @@ def test_main_function(mocker: MockerFixture) -> None:
             "latest",
             "--nodejs",
             "both",
+            "--php",
+            "stable",
             "--dry-run",
         ],
     )
@@ -321,7 +324,7 @@ def test_main_function(mocker: MockerFixture) -> None:
     main()
     mock_update.assert_called_with(
         os.path.join(".github", "json2vars-setter", "matrix.json"),  # Default path
-        {"python": "latest", "nodejs": "both"},
+        {"python": "latest", "nodejs": "both", "php": "stable"},
         True,  # dry_run=True
     )
 

--- a/tests/version/fetchers/test_php.py
+++ b/tests/version/fetchers/test_php.py
@@ -1,0 +1,227 @@
+from typing import List, cast
+
+import pytest
+import pytest_mock
+
+from json2vars_setter.version.core.exceptions import ParseError
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
+from json2vars_setter.version.fetchers.php import PhpVersionFetcher, php_filter_func
+
+
+@pytest.fixture
+def php_fetcher() -> PhpVersionFetcher:
+    """Fixture to create a PhpVersionFetcher instance"""
+    return PhpVersionFetcher()
+
+
+def test_init(php_fetcher: PhpVersionFetcher) -> None:
+    """Test __init__ sets the correct GitHub repository information"""
+    assert php_fetcher.github_owner == "php"
+    assert php_fetcher.github_repo == "php-src"
+
+
+def test_is_stable_tag(php_fetcher: PhpVersionFetcher) -> None:
+    """Test _is_stable_tag method with various tag scenarios"""
+    # Stable version tags
+    stable_tags: List[JsonObject] = [
+        {"name": "php-8.3.0"},
+        {"name": "php-8.4.1"},
+        {"name": "php-7.4.33"},
+    ]
+
+    # Unstable / unrelated tags
+    unstable_tags: List[JsonObject] = [
+        {"name": "php-8.5.0RC1"},
+        {"name": "php-8.5.0beta1"},
+        {"name": "php-8.5.0alpha2"},
+        {"name": "yaf-2.1.0"},  # unrelated project tag
+        {"name": "security-audit-2024"},
+        {"name": "php-8.4"},  # only two components
+        {"name": ""},  # empty name
+    ]
+
+    # Test stable tags
+    for tag in stable_tags:
+        assert php_fetcher._is_stable_tag(tag) is True
+
+    # Test unstable tags
+    for tag in unstable_tags:
+        assert php_fetcher._is_stable_tag(tag) is False
+
+
+def test_parse_version_from_tag(php_fetcher: PhpVersionFetcher) -> None:
+    """Test _parse_version_from_tag method"""
+    # Valid tag
+    valid_tag: JsonObject = {
+        "name": "php-8.3.2",
+        "commit": {"sha": "abc123"},
+        "tarball_url": "https://example.com/tarball",
+        "zipball_url": "https://example.com/zipball",
+    }
+
+    release_info: ReleaseInfo = php_fetcher._parse_version_from_tag(valid_tag)
+
+    assert release_info.version == "8.3.2"
+    assert release_info.prerelease is False
+    assert release_info.additional_info["tag_name"] == "php-8.3.2"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
+    assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
+    assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
+
+    # Invalid tag (no name)
+    with pytest.raises(ParseError):
+        php_fetcher._parse_version_from_tag({"name": ""})
+
+
+def test_get_stability_criteria(php_fetcher: PhpVersionFetcher) -> None:
+    """Test _get_stability_criteria method"""
+    # Prepare sample releases
+    releases: List[ReleaseInfo] = [
+        ReleaseInfo(version="8.4.1"),
+        ReleaseInfo(version="8.3.6"),
+        ReleaseInfo(version="8.2.15"),
+        ReleaseInfo(version="8.1.27"),
+    ]
+
+    latest, stable = php_fetcher._get_stability_criteria(releases)
+
+    assert latest.version == "8.4.1"
+    assert stable.version == "8.3.6"
+
+    # Case with single release
+    single_release: List[ReleaseInfo] = [ReleaseInfo(version="8.4.1")]
+    latest, stable = php_fetcher._get_stability_criteria(single_release)
+
+    assert latest.version == "8.4.1"
+    assert stable.version == "8.4.1"
+
+    # Empty releases case
+    with pytest.raises(ValueError):
+        php_fetcher._get_stability_criteria([])
+
+
+def test_php_filter_func() -> None:
+    """Test php_filter_func with various tag names"""
+    # Stable tags
+    stable_tags: List[JsonObject] = [
+        {"name": "php-8.3.0"},
+        {"name": "php-8.4.1"},
+        {"name": "php-7.4.33"},
+    ]
+
+    # Unstable / unrelated tags
+    unstable_tags: List[JsonObject] = [
+        {"name": "php-8.5.0RC1"},
+        {"name": "php-8.5.0beta1"},
+        {"name": "php-8.5.0alpha2"},
+        {"name": "yaf-2.1.0"},
+        {"name": "security-audit-2024"},
+        {"name": "php-8.4"},
+        {"name": "latest"},
+        {"name": ""},
+    ]
+
+    # Test stable tags
+    for tag in stable_tags:
+        assert php_filter_func(tag) is True
+
+    # Test unstable tags
+    for tag in unstable_tags:
+        assert php_filter_func(tag) is False
+
+
+def test_fetch_versions_integration(
+    php_fetcher: PhpVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """
+    Test fetch_versions method with mocked API calls
+    """
+    # Prepare mock tags
+    mock_tags: List[JsonObject] = [
+        {
+            "name": "php-8.4.1",
+            "commit": {"sha": "abc123"},
+            "tarball_url": "https://example.com/tarball/8.4.1",
+            "zipball_url": "https://example.com/zipball/8.4.1",
+        },
+        {
+            "name": "php-8.3.6",
+            "commit": {"sha": "def456"},
+            "tarball_url": "https://example.com/tarball/8.3.6",
+            "zipball_url": "https://example.com/zipball/8.3.6",
+        },
+    ]
+
+    # Mock _get_github_tags method to return predefined tags
+    mocker.patch.object(php_fetcher, "_get_github_tags", return_value=mock_tags)
+
+    # Fetch versions
+    versions = php_fetcher.fetch_versions(recent_count=2)
+
+    # Validate results
+    assert versions.latest == "8.4.1"
+    assert versions.stable == "8.3.6"
+    assert len(versions.recent_releases) == 2
+
+    # Check details
+    assert "fetch_time" in versions.details
+    assert versions.details["source"] == "github:php/php-src"
+    assert "latest_info" in versions.details
+    assert "stable_info" in versions.details
+
+
+def test_get_stability_criteria_invalid_latest_version(
+    php_fetcher: PhpVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria when the latest version is unparsable"""
+    # Mock logger
+    mocker.patch.object(php_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="invalid"),  # latest does not match the semver regex
+        ReleaseInfo(version="8.3.6"),
+    ]
+
+    latest, stable = php_fetcher._get_stability_criteria(releases)
+
+    # When latest cannot be parsed, it falls back to using latest as stable
+    assert latest.version == "invalid"
+    assert stable.version == "invalid"
+
+
+def test_get_stability_criteria_no_previous_minor(
+    php_fetcher: PhpVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria when no previous minor version exists"""
+    # Mock logger
+    mocker.patch.object(php_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="8.4.0"),
+        ReleaseInfo(version="8.4.1"),  # Same minor version
+        ReleaseInfo(version="7.4.33"),  # Different major version
+    ]
+
+    latest, stable = php_fetcher._get_stability_criteria(releases)
+
+    assert latest.version == "8.4.0"
+    assert stable.version == "8.4.0"  # Use latest as no previous minor version exists
+
+
+def test_get_stability_criteria_invalid_release_version(
+    php_fetcher: PhpVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria with an invalid version in the releases list"""
+    # Mock logger
+    mocker.patch.object(php_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="8.4.1"),
+        ReleaseInfo(version="8.3.invalid"),  # Does not match regex, must be skipped
+        ReleaseInfo(version="8.3.6"),
+    ]
+
+    latest, stable = php_fetcher._get_stability_criteria(releases)
+
+    assert latest.version == "8.4.1"
+    assert stable.version == "8.3.6"  # Skip invalid and select correct stable version

--- a/tests/version/test_registry.py
+++ b/tests/version/test_registry.py
@@ -4,6 +4,7 @@ import pytest
 
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
 from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
+from json2vars_setter.version.fetchers.php import PhpVersionFetcher
 from json2vars_setter.version.fetchers.python import PythonVersionFetcher
 from json2vars_setter.version.fetchers.ruby import RubyVersionFetcher
 from json2vars_setter.version.fetchers.rust import RustVersionFetcher
@@ -17,6 +18,7 @@ def test_get_version_fetcher_returns_expected_type() -> None:
     assert isinstance(get_version_fetcher("ruby"), RubyVersionFetcher)
     assert isinstance(get_version_fetcher("go"), GoVersionFetcher)
     assert isinstance(get_version_fetcher("rust"), RustVersionFetcher)
+    assert isinstance(get_version_fetcher("php"), PhpVersionFetcher)
 
 
 def test_get_version_fetcher_unsupported_language() -> None:


### PR DESCRIPTION
## Summary

Add **PHP** as a supported language (Tier 1). Versions are fetched from the
`php/php-src` tags, and the change includes the full repo structure: fetcher,
action contract, tests, example project, CI workflow, status badges, and docs.

Closes #504

## Changes

### Core
- **`version/fetchers/php.py`**: `PhpVersionFetcher` (`php/php-src`) + `php_filter_func`
  - Stable detection: tag fully matches `php-X.Y.Z` (`php-8.5.0RC1`, `php-8.5.0beta1`,
    `yaf-2.1.0`, etc. are excluded)
  - `stable` = previous minor of `latest` (same approach as Go/Ruby)
- **`version/registry.py`**: register `"php"` in `LANGUAGE_FETCHERS`
- **`features/matrix_update.py`**: `--php` strategy arg (+ `--all` / `main()` wiring)
- **`action.yml`**: `php-strategy` input, `versions_php` output, strategy arg, summary echo

### Tests (100% coverage)
- `tests/version/fetchers/test_php.py` (covers `php.py` fully)
- `tests/version/test_registry.py`, `tests/features/test_matrix_update.py` updates

### Example project & CI
- `examples/php/`: composer-based JSON-parser sample (src, tests, `phpunit.xml`,
  `php_project_matrix.json`, README) mirroring `examples/ruby/`
- `.github/workflows/php_test.yml`: `set_variables` -> `run_tests` (OS x PHP matrix
  via `shivammathur/setup-php`) -> `update_badge` (dedicated gist)

### Badges & docs
- `README.md` / `docs/index.md`: PHP status badge row (gist `php-test-badge.json`)
  + supported-languages prose
- `docs/reference/options.md`, `docs/features/dynamic-update.md`,
  `docs/features/index.md`, `CLAUDE.md`
- `CLAUDE.md`: new **"Adding a New Language"** checklist covering every layer
  (code, action contract, tests, example, workflow, badges, docs)

## Action interface

PHP uses the **same action interface as every other language** — there is nothing
PHP-specific in how the action is called:

- input: `php-strategy` (mirrors `python-strategy`, `ruby-strategy`, ...)
- output: `versions_php` (mirrors `versions_python`, ...)

The only PHP-specific parts live **outside** this action: the consumer uses
`shivammathur/setup-php`, and the example matrix uses the `major.minor` version
format (`"8.2"`, `"8.3"`, `"8.4"`) that setup-php accepts. (The fetcher itself still
returns full `X.Y.Z` versions like the other languages.)

> A version-pinned usage example is intentionally omitted here: PHP is not in any
> published tag yet, so a `@vX.Y.Z` snippet would not work. Once this ships (v1.4.0),
> usage is identical to the other languages' examples in the README/docs, just with
> `php-strategy` / `versions_php`.

## Verification

| Check | Result |
|---|---|
| `mypy --config-file=pyproject.toml` | Pass (39 files, strict + no-Any) |
| `ruff check` / `ruff format --check` | Pass |
| `pytest` + coverage | 215 passed, 100% coverage (`php.py` 100%) |
| `php_test.yml` (CI) | Pass (OS x PHP 8.2/8.3/8.4) |

## Release ordering (two-phase action reference)

A new language''s `versions_php` output does not exist in the published tag until the
release that adds it, so a tag ref (`@vX.Y.Z`) in `php_test.yml` would fail on this PR.
To keep CI green, `php_test.yml` uses `uses: ./` (the in-repo action) for now.

**Follow-up after the PHP release (v1.4.0):** switch that step to the pinned tag
`uses: 7rikazhexde/json2vars-setter@v1.4.0` to match the other `*_test.yml` workflows
and the Versioning Rule. Tracked via a `TODO` in the workflow and CLAUDE.md
"Adding a New Language" (point 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)