### PR TITLE
:pushpin: Pin php_test.yml to json2vars-setter@v1.4.0

### DIFF
--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds PHP): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.4.0
         with:
           json-file: examples/php/php_project_matrix.json
 


### PR DESCRIPTION
## Summary

PHP support shipped in **v1.4.0**, so the published tag now exposes `versions_php`.
Switch `php_test.yml` from the in-repo `uses: ./` to the pinned release tag
`uses: 7rikazhexde/json2vars-setter@v1.4.0`.

This completes the documented two-phase action reference for a new language
(see CLAUDE.md "Adding a New Language", point 9): `uses: ./` on the introducing PR
to stay green before release, then the pinned tag afterwards so it matches every
other `*_test.yml` and the Versioning Rule. From here on `sync-version-refs.sh`
keeps it pinned to the latest release.

## Verification

- `php_test.yml` now resolves `versions_php` from the published `@v1.4.0` action, so
  the PHP Test workflow runs the OS x PHP matrix as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)