### PR TITLE
:sparkles: Add .NET (C#) version support

### DIFF
--- a/.github/workflows/dotnet_test.yml
+++ b/.github/workflows/dotnet_test.yml
@@ -1,0 +1,158 @@
+name: .NET Test
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'examples/dotnet/**'
+      - '.github/workflows/dotnet_test.yml'
+
+jobs:
+  set_variables:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.json2vars.outputs.os }}
+      versions_dotnet: ${{ steps.json2vars.outputs.versions_dotnet }}
+      ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set variables from JSON
+        id: json2vars
+        # Use the in-repo action so this workflow tests the current code. A new
+        # language's `versions_<lang>` output does not exist in the published tag
+        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
+        # until then; `./` keeps the example workflow green from the first PR.
+        # TODO(after the release that adds .NET): switch to the pinned tag
+        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
+        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
+        uses: ./
+        with:
+          json-file: examples/dotnet/dotnet_project_matrix.json
+
+      - name: Debug output values
+        run: |
+          echo "os: ${{ steps.json2vars.outputs.os }}"
+          echo "os[0]: ${{ fromJson(steps.json2vars.outputs.os)[0] }}"
+          echo "os[1]: ${{ fromJson(steps.json2vars.outputs.os)[1] }}"
+          echo "os[2]: ${{ fromJson(steps.json2vars.outputs.os)[2] }}"
+          echo "versions_dotnet: ${{ steps.json2vars.outputs.versions_dotnet }}"
+          echo "versions_dotnet[0]: ${{ fromJson(steps.json2vars.outputs.versions_dotnet)[0] }}"
+          echo "versions_dotnet[1]: ${{ fromJson(steps.json2vars.outputs.versions_dotnet)[1] }}"
+          echo "ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}"
+
+  run_tests:
+    needs: set_variables
+    strategy:
+      # Run every matrix combination even if one fails so the aggregated job
+      # result reflects the status of the whole matrix (used by the badge).
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.set_variables.outputs.os) }}
+        dotnet-version: ${{ fromJson(needs.set_variables.outputs.versions_dotnet) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Set timezone
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
+        with:
+          timezoneLinux: "Asia/Tokyo"
+          timezoneMacos: "Asia/Tokyo"
+          timezoneWindows: "Tokyo Standard Time"
+
+      - name: Display .NET version
+        run: dotnet --info
+
+      - name: Show matrix
+        shell: bash
+        run: |
+          # For non-list case
+          ghpages_branch="${{ needs.set_variables.outputs.ghpages_branch }}"
+
+          # For list case, explicitly enclose the list in "" to make it a string. (Note that it is not ''.)
+          os='${{ needs.set_variables.outputs.os }}'
+          versions_dotnet='${{ needs.set_variables.outputs.versions_dotnet }}'
+
+          # For list index case
+          os_0="${{ fromJson(needs.set_variables.outputs.os)[0] }}"
+          os_1="${{ fromJson(needs.set_variables.outputs.os)[1] }}"
+          os_2="${{ fromJson(needs.set_variables.outputs.os)[2] }}"
+
+          versions_dotnet_0="${{ fromJson(needs.set_variables.outputs.versions_dotnet)[0] }}"
+          versions_dotnet_1="${{ fromJson(needs.set_variables.outputs.versions_dotnet)[1] }}"
+
+          echo "os: ${os}"
+          echo "os_0: ${os_0}"
+          echo "os_1: ${os_1}"
+          echo "os_2: ${os_2}"
+          echo "versions_dotnet: ${versions_dotnet}"
+          echo "versions_dotnet_0: ${versions_dotnet_0}"
+          echo "versions_dotnet_1: ${versions_dotnet_1}"
+          echo "ghpages_branch: ${ghpages_branch}"
+
+          # For loop case
+          os_list=$(echo "${os}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          dotnet_versions_list=$(echo "${versions_dotnet}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+
+          for current_os in ${os_list}; do
+            for version in ${dotnet_versions_list}; do
+              echo "Current OS: ${current_os}, Current .NET Version: ${version}"
+            done
+          done
+
+      - name: Run tests
+        id: dotnet_test
+        working-directory: ./examples/dotnet
+        shell: bash
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
+        run: |
+          dotnet test
+
+  update_badge:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Determine status and color
+        id: status
+        shell: bash
+        run: |
+          # needs.run_tests.result aggregates every matrix combination:
+          # 'success' only when all passed, 'failure' if any leg failed.
+          case "${{ needs.run_tests.result }}" in
+            success)   status=passing;   color=2ea44f ;;
+            failure)   status=failing;   color=cf222e ;;
+            cancelled) status=cancelled; color=808080 ;;
+            skipped)   status=skipped;   color=808080 ;;
+            *)         status=pending;   color=dbab09 ;;
+          esac
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
+
+      - name: Create badge
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 33c8a05d3ed6c038877d847ffc12b2f9
+          filename: dotnet-test-badge.json
+          label: .NET Test
+          message: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          labelColor: "24292f"
+          style: "flat"
+          namedLogo: "github"
+          logoColor: "white"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, and PHP. The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
+json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, PHP, and .NET (C#). The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
 
 ## Common Commands
 
@@ -79,7 +79,7 @@ A pluggable architecture for fetching language versions from GitHub:
 - **`version/core/base.py`** — `BaseVersionFetcher` abstract class handles GitHub API pagination, authentication (via `GITHUB_TOKEN`), and defines the interface (`_is_stable_tag()`, `_parse_version_from_tag()`)
 - **`version/core/exceptions.py`** — Exception hierarchy: `VersionFetchError` → `GitHubAPIError`, `ParseError`, `ValidationError`
 - **`version/core/utils.py`** — Shared data classes (`VersionInfo`, `ReleaseInfo`) and helpers
-- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`), each parsing tags from the respective GitHub repository
+- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`, `dotnet.py`), each parsing tags from the respective GitHub repository
 
 ### Entry Points
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, and PHP
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, and .NET (C#)
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -39,6 +39,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![Go](https://img.shields.io/badge/Go-00ADD8?style=flat&logo=go&logoColor=white) | [![setup-go](https://img.shields.io/badge/setup--go-00ADD8?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-go-environment) | [![Go Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/c334da204406866563668140885d170e/raw/go-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/go_test.yml) |
 | ![Rust](https://img.shields.io/badge/Rust-000000?style=flat&logo=rust&logoColor=white) | [![rust-toolchain](https://img.shields.io/badge/rust--toolchain-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/rustup-toolchain-install) | [![Rust Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5e160d06cfffd42a8f0e4ae6e8e8f025/raw/rust-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/rust_test.yml) |
 | ![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat&logo=php&logoColor=white) | [![setup-php](https://img.shields.io/badge/setup--php-777BB4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-php-action) | [![PHP Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/a9bc428c9f5a2f998bd7307038e557e1/raw/php-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/php_test.yml) |
+| ![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white) | [![setup-dotnet](https://img.shields.io/badge/setup--dotnet-512BD4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-dotnet) | [![.NET Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/33c8a05d3ed6c038877d847ffc12b2f9/raw/dotnet-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/dotnet_test.yml) |
 
 ## Quick Start
 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
   php-strategy:
     description: 'Update strategy for PHP versions (stable, latest, or both)'
     required: false  # Optional
+  dotnet-strategy:
+    description: 'Update strategy for .NET (C#) versions (stable, latest, or both)'
+    required: false  # Optional
 
   # Safe Mode
   dry-run:
@@ -132,6 +135,9 @@ outputs:
   versions_php:
     description: 'List of PHP versions'
     value: ${{ steps.set_outputs.outputs.versions_php }}
+  versions_dotnet:
+    description: 'List of .NET (C#) versions'
+    value: ${{ steps.set_outputs.outputs.versions_dotnet }}
   ghpages_branch:
     description: 'GitHub Pages branch'
     value: ${{ steps.set_outputs.outputs.ghpages_branch }}
@@ -198,6 +204,9 @@ runs:
           fi
           if [[ -n "${{ inputs.php-strategy }}" ]]; then
             ARGS+=("--php" "${{ inputs.php-strategy }}")
+          fi
+          if [[ -n "${{ inputs.dotnet-strategy }}" ]]; then
+            ARGS+=("--dotnet" "${{ inputs.dotnet-strategy }}")
           fi
         fi
 
@@ -318,4 +327,5 @@ runs:
         echo "Go Versions: ${{ steps.set_outputs.outputs.versions_go }}"
         echo "Rust Versions: ${{ steps.set_outputs.outputs.versions_rust }}"
         echo "PHP Versions: ${{ steps.set_outputs.outputs.versions_php }}"
+        echo ".NET Versions: ${{ steps.set_outputs.outputs.versions_dotnet }}"
         echo "GitHub Pages Branch: ${{ steps.set_outputs.outputs.ghpages_branch }}"

--- a/docs/features/dynamic-update.md
+++ b/docs/features/dynamic-update.md
@@ -193,6 +193,7 @@ The Dynamic Matrix Updater accepts the following inputs:
 | `go-strategy` | Strategy for Go versions | No | - |
 | `rust-strategy` | Strategy for Rust versions | No | - |
 | `php-strategy` | Strategy for PHP versions | No | - |
+| `dotnet-strategy` | Strategy for .NET (C#) versions | No | - |
 | `dry-run` | Run without updating the file | No | `'false'` |
 
 ## How It Works
@@ -244,6 +245,7 @@ The Dynamic Matrix Updater currently supports:
 - **Go**: Fetches from Go releases via GitHub API
 - **Rust**: Fetches from Rust releases via GitHub API
 - **PHP**: Fetches from PHP releases via GitHub API
+- **.NET (C#)**: Fetches from .NET SDK releases via GitHub API
 
 ## Best Practices
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -109,7 +109,7 @@ graph LR
 - **Automated Version Updates**: Keep testing matrices current without manual intervention
 - **Efficient API Usage**: Reduce external API calls by caching version information
 - **Cross-Platform Testing**: Define operating systems and language versions for comprehensive testing
-- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, and PHP in a single configuration
+- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, PHP, and .NET (C#) in a single configuration
 
 ## Component Integration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, and PHP
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, and .NET (C#)
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -26,6 +26,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![Go](https://img.shields.io/badge/Go-00ADD8?style=flat&logo=go&logoColor=white) | [![setup-go](https://img.shields.io/badge/setup--go-00ADD8?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-go-environment) | [![Go Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/c334da204406866563668140885d170e/raw/go-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/go_test.yml) |
 | ![Rust](https://img.shields.io/badge/Rust-000000?style=flat&logo=rust&logoColor=white) | [![rust-toolchain](https://img.shields.io/badge/rust--toolchain-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/rustup-toolchain-install) | [![Rust Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5e160d06cfffd42a8f0e4ae6e8e8f025/raw/rust-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/rust_test.yml) |
 | ![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat&logo=php&logoColor=white) | [![setup-php](https://img.shields.io/badge/setup--php-777BB4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-php-action) | [![PHP Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/a9bc428c9f5a2f998bd7307038e557e1/raw/php-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/php_test.yml) |
+| ![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white) | [![setup-dotnet](https://img.shields.io/badge/setup--dotnet-512BD4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-dotnet) | [![.NET Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/33c8a05d3ed6c038877d847ffc12b2f9/raw/dotnet-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/dotnet_test.yml) |
 
 ## Quick Start
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -22,6 +22,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `go-strategy` | Update strategy for Go versions | ✗ | - | Same valid values as `update-strategy` |
 | `rust-strategy` | Update strategy for Rust versions | ✗ | - | Same valid values as `update-strategy` |
 | `php-strategy` | Update strategy for PHP versions | ✗ | - | Same valid values as `update-strategy` |
+| `dotnet-strategy` | Update strategy for .NET (C#) versions | ✗ | - | Same valid values as `update-strategy` |
 | `dry-run` | Run in dry-run mode without updating the JSON file | ✗ | `false` | For testing update strategies |
 
 ### Cache Version Options
@@ -52,6 +53,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `versions_go` | List of Go versions | `["1.19", "1.20", "1.21"]` |
 | `versions_rust` | List of Rust versions | `["1.70.0", "1.71.0", "stable"]` |
 | `versions_php` | List of PHP versions | `["8.2.0", "8.3.0", "8.4.0"]` |
+| `versions_dotnet` | List of .NET (C#) versions | `["8.0.100", "9.0.100"]` |
 | `ghpages_branch` | GitHub Pages branch name | `"gh-pages"` |
 
 ## Usage Notes

--- a/examples/dotnet/JsonParser.cs
+++ b/examples/dotnet/JsonParser.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+
+namespace JsonVarsSetter;
+
+/// <summary>
+/// Minimal JSON configuration parser used to demonstrate consuming the
+/// json2vars-setter matrix file in a .NET (C#) project.
+/// </summary>
+public static class JsonParser
+{
+    /// <summary>
+    /// Parse a JSON configuration file into a dictionary of JSON elements.
+    /// </summary>
+    /// <param name="filePath">Path to the JSON file.</param>
+    /// <param name="silent">When true, suppress error output.</param>
+    /// <returns>The parsed data, or null on failure.</returns>
+    public static Dictionary<string, JsonElement>? ParseConfig(
+        string filePath,
+        bool silent = false)
+    {
+        try
+        {
+            var contents = File.ReadAllText(filePath);
+            return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(contents);
+        }
+        catch (Exception e)
+        {
+            if (!silent)
+            {
+                Console.Error.WriteLine($"Error reading or parsing JSON: {e.Message}");
+            }
+
+            return null;
+        }
+    }
+}

--- a/examples/dotnet/JsonParserExample.csproj
+++ b/examples/dotnet/JsonParserExample.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <!-- Allow the net8.0 test host to run on a newer-only runtime (e.g. when the
+         matrix installs only the 9.0 SDK/runtime). -->
+    <RollForward>LatestMajor</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Make the matrix file available next to the test assembly at runtime. -->
+    <None Include="dotnet_project_matrix.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/examples/dotnet/JsonParserTests.cs
+++ b/examples/dotnet/JsonParserTests.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using JsonVarsSetter;
+using Xunit;
+
+namespace JsonVarsSetter.Tests;
+
+public class JsonParserTests
+{
+    private readonly string _configPath =
+        Path.Combine(AppContext.BaseDirectory, "dotnet_project_matrix.json");
+
+    [Fact]
+    public void ParsesJsonFile()
+    {
+        var result = JsonParser.ParseConfig(_configPath);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void ParsesExpectedValues()
+    {
+        var result = JsonParser.ParseConfig(_configPath);
+        Assert.NotNull(result);
+
+        var os = result!["os"].EnumerateArray()
+            .Select(e => e.GetString())
+            .ToList();
+        Assert.Contains("ubuntu-latest", os);
+        Assert.Contains("windows-latest", os);
+        Assert.Contains("macos-latest", os);
+
+        var versions = result["versions"].GetProperty("dotnet").EnumerateArray()
+            .Select(e => e.GetString())
+            .ToList();
+        Assert.Equal(new[] { "8.0", "9.0" }, versions);
+
+        Assert.Equal("ghgapes", result["ghpages_branch"].GetString());
+    }
+
+    [Fact]
+    public void ReturnsNullForMissingFile()
+    {
+        var result = JsonParser.ParseConfig("non-existent.json", silent: true);
+        Assert.Null(result);
+    }
+}

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -1,0 +1,48 @@
+# .NET (C#) Example for json2vars-setter
+
+This is a .NET (C#) implementation example for parsing JSON configuration files in
+GitHub Actions matrix testing.
+
+## Requirements
+
+- .NET SDK 8.0 or newer
+
+## Project Structure
+
+```bash
+.
+├── JsonParserExample.csproj   # Project + test dependencies (xUnit)
+├── JsonParser.cs              # Main implementation
+├── JsonParserTests.cs         # Test implementation
+└── dotnet_project_matrix.json # Matrix definition consumed by json2vars-setter
+```
+
+## Setup & Running
+
+Restore and run the tests:
+
+```bash
+cd examples/dotnet
+dotnet test
+```
+
+## Matrix file
+
+`dotnet_project_matrix.json` defines the OS list and .NET versions used by the matrix
+testing workflow. The versions use the channel form accepted by
+[`actions/setup-dotnet`](https://github.com/marketplace/actions/setup-dotnet):
+
+```json
+{
+    "os": ["ubuntu-latest", "windows-latest", "macos-latest"],
+    "versions": {
+        "dotnet": ["8.0", "9.0"]
+    },
+    "ghpages_branch": "ghgapes"
+}
+```
+
+The project targets `net8.0` with `RollForward=LatestMajor`, so the same test
+assembly builds and runs on every SDK in the matrix. The
+`.github/workflows/dotnet_test.yml` workflow reads this file through json2vars-setter
+and runs the tests across every OS / .NET version combination.

--- a/examples/dotnet/dotnet_project_matrix.json
+++ b/examples/dotnet/dotnet_project_matrix.json
@@ -1,0 +1,14 @@
+{
+    "os": [
+        "ubuntu-latest",
+        "windows-latest",
+        "macos-latest"
+    ],
+    "versions": {
+        "dotnet": [
+            "8.0",
+            "9.0"
+        ]
+    },
+    "ghpages_branch": "ghgapes"
+}

--- a/json2vars_setter/features/matrix_update.py
+++ b/json2vars_setter/features/matrix_update.py
@@ -270,6 +270,11 @@ Examples:
         help="Strategy for PHP versions",
     )
     parser.add_argument(
+        "--dotnet",
+        choices=["stable", "latest", "both"],
+        help="Strategy for .NET (C#) versions",
+    )
+    parser.add_argument(
         "--all",
         choices=["stable", "latest", "both"],
         help="Apply the same strategy to all languages",
@@ -303,6 +308,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         args.go = args.all
         args.rust = args.all
         args.php = args.all
+        args.dotnet = args.all
 
     # Collect language strategies
     language_strategies: Dict[str, str] = {}
@@ -318,6 +324,8 @@ def main(argv: Optional[List[str]] = None) -> None:
         language_strategies["rust"] = args.rust
     if args.php:
         language_strategies["php"] = args.php
+    if args.dotnet:
+        language_strategies["dotnet"] = args.dotnet
 
     if not language_strategies:
         parser.error("At least one language strategy must be specified")

--- a/json2vars_setter/version/fetchers/dotnet.py
+++ b/json2vars_setter/version/fetchers/dotnet.py
@@ -1,0 +1,193 @@
+import os
+import re
+from typing import List, Tuple, cast
+
+import requests
+
+from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.core.exceptions import ParseError
+from json2vars_setter.version.core.utils import (
+    JsonObject,
+    ReleaseInfo,
+    check_github_api,
+    setup_logging,
+)
+
+# Stable .NET SDK tags look exactly like "v8.0.100"; pre-releases append a suffix
+# (e.g. "v11.0.100-preview.4.26230.115", "v10.0.100-rc.1.25451.107").
+_STABLE_TAG_PATTERN = re.compile(r"v\d+\.\d+\.\d+$")
+
+
+class DotnetVersionFetcher(BaseVersionFetcher):
+    """Fetches .NET SDK version information from GitHub"""
+
+    def __init__(self) -> None:
+        """Initialize with the .NET SDK GitHub repository information"""
+        super().__init__("dotnet", "sdk")
+
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
+        """
+        Check if a tag represents a stable .NET SDK release
+
+        Args:
+            tag: Tag information from GitHub API
+
+        Returns:
+            True if the tag represents a stable release, False otherwise
+        """
+        name = str(tag.get("name", ""))
+
+        # .NET SDK uses format "vX.Y.Z" for stable releases
+        return bool(_STABLE_TAG_PATTERN.fullmatch(name))
+
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
+        """
+        Parse version information from a .NET SDK tag
+
+        Args:
+            tag: Tag information from GitHub API
+
+        Returns:
+            Parsed ReleaseInfo object
+
+        Raises:
+            ParseError: If required version information cannot be parsed
+        """
+        name = str(tag.get("name", ""))
+        if not name:
+            raise ParseError("No tag name found")
+
+        # Clean version string (e.g., "v8.0.100" -> "8.0.100")
+        version = name.removeprefix("v")
+
+        # All filtered tags are considered stable
+        prerelease = False
+
+        return ReleaseInfo(
+            version=version,
+            release_date=None,
+            prerelease=prerelease,
+            additional_info={
+                "tag_name": name,
+                "commit": {"sha": cast(JsonObject, tag.get("commit", {})).get("sha")},
+                "tarball_url": tag.get("tarball_url"),
+                "zipball_url": tag.get("zipball_url"),
+            },
+        )
+
+    def _get_stability_criteria(
+        self, releases: List[ReleaseInfo]
+    ) -> Tuple[ReleaseInfo, ReleaseInfo]:
+        """
+        Determine the stable and latest versions of the .NET SDK
+
+        Unlike most languages, the .NET SDK minor component is always ``0`` and the
+        meaningful release line is the **major** version (8.0, 9.0, 10.0 ...), so:
+        - latest: the most recent SDK release
+        - stable: the newest SDK of the previous major version, when present
+
+        Args:
+            releases: List of release information
+
+        Returns:
+            Tuple of (latest_release, stable_release)
+        """
+        if not releases:
+            # Raise an exception to explicitly handle the case where no releases are available
+            raise ValueError("No releases available")
+
+        # The latest version is always the first release
+        latest = releases[0]
+
+        # Get and parse the version number
+        latest_version = latest.version
+        match = re.match(r"(\d+)\.(\d+)\.(\d+)", latest_version)
+
+        if match:
+            major = int(match.group(1))
+            # Look for the previous major version
+            prev_major = major - 1
+
+            # Search for the newest release with the previous major version
+            for release in releases:
+                r_match = re.match(r"(\d+)\.(\d+)\.(\d+)", release.version)
+                if r_match and int(r_match.group(1)) == prev_major:
+                    self.logger.info(
+                        f"Using {release.version} as stable vs latest {latest_version}"
+                    )
+                    return latest, release
+
+        # Use the latest version if no suitable stable version is found
+        self.logger.info(
+            f"No suitable stable version found, using latest {latest_version} as stable"
+        )
+        return latest, latest
+
+
+def dotnet_filter_func(tag: JsonObject) -> bool:
+    """Filter function for .NET SDK tags in API checker"""
+    name = str(tag.get("name", ""))
+    return bool(_STABLE_TAG_PATTERN.fullmatch(name))
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Fetch .NET SDK version information")
+    parser.add_argument(
+        "--count", type=int, default=5, help="Number of versions to fetch"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="count", default=0, help="Increase verbosity"
+    )
+    args = parser.parse_args()
+
+    # Set up logging
+    logger = setup_logging(args.verbose)
+
+    # Check API directly if in verbose mode
+    if args.verbose > 0:
+        # Create a session for API checking
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "json2vars-setter",
+            }
+        )
+
+        # Add GitHub token if available
+        github_token = os.environ.get("GITHUB_TOKEN")
+        if github_token:
+            session.headers.update({"Authorization": f"token {github_token}"})
+
+        check_github_api(
+            session=session,
+            github_owner="dotnet",
+            github_repo="sdk",
+            count=args.count,
+            filter_func=dotnet_filter_func,
+        )
+
+    # Display header in verbose mode
+    if args.verbose > 0:
+        print("\n=== Fetching .NET SDK Versions ===")
+
+    # Main processing
+    fetcher = DotnetVersionFetcher()
+    versions = fetcher.fetch_versions(recent_count=args.count)
+
+    # Output results
+    print(
+        json.dumps(
+            {
+                "latest": versions.latest,
+                "stable": versions.stable,
+                "recent_releases": [vars(r) for r in versions.recent_releases],
+                "details": versions.details,
+            },
+            indent=2,
+        )
+    )

--- a/json2vars_setter/version/registry.py
+++ b/json2vars_setter/version/registry.py
@@ -8,6 +8,7 @@ shared by the matrix-update and version-cache features.
 from typing import Callable, Dict
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.fetchers.dotnet import DotnetVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
 from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
 from json2vars_setter.version.fetchers.php import PhpVersionFetcher
@@ -24,6 +25,7 @@ LANGUAGE_FETCHERS: Dict[str, Callable[[], BaseVersionFetcher]] = {
     "go": GoVersionFetcher,
     "rust": RustVersionFetcher,
     "php": PhpVersionFetcher,
+    "dotnet": DotnetVersionFetcher,
 }
 
 

--- a/tests/features/test_matrix_update.py
+++ b/tests/features/test_matrix_update.py
@@ -302,6 +302,7 @@ def test_main_function(mocker: MockerFixture) -> None:
             "go": "stable",
             "rust": "stable",
             "php": "stable",
+            "dotnet": "stable",
         },
         False,
     )
@@ -317,6 +318,8 @@ def test_main_function(mocker: MockerFixture) -> None:
             "both",
             "--php",
             "stable",
+            "--dotnet",
+            "latest",
             "--dry-run",
         ],
     )
@@ -324,7 +327,7 @@ def test_main_function(mocker: MockerFixture) -> None:
     main()
     mock_update.assert_called_with(
         os.path.join(".github", "json2vars-setter", "matrix.json"),  # Default path
-        {"python": "latest", "nodejs": "both", "php": "stable"},
+        {"python": "latest", "nodejs": "both", "php": "stable", "dotnet": "latest"},
         True,  # dry_run=True
     )
 

--- a/tests/version/fetchers/test_dotnet.py
+++ b/tests/version/fetchers/test_dotnet.py
@@ -1,0 +1,224 @@
+from typing import List, cast
+
+import pytest
+import pytest_mock
+
+from json2vars_setter.version.core.exceptions import ParseError
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
+from json2vars_setter.version.fetchers.dotnet import (
+    DotnetVersionFetcher,
+    dotnet_filter_func,
+)
+
+
+@pytest.fixture
+def dotnet_fetcher() -> DotnetVersionFetcher:
+    """Fixture to create a DotnetVersionFetcher instance"""
+    return DotnetVersionFetcher()
+
+
+def test_init(dotnet_fetcher: DotnetVersionFetcher) -> None:
+    """Test __init__ sets the correct GitHub repository information"""
+    assert dotnet_fetcher.github_owner == "dotnet"
+    assert dotnet_fetcher.github_repo == "sdk"
+
+
+def test_is_stable_tag(dotnet_fetcher: DotnetVersionFetcher) -> None:
+    """Test _is_stable_tag method with various tag scenarios"""
+    # Stable version tags
+    stable_tags: List[JsonObject] = [
+        {"name": "v8.0.100"},
+        {"name": "v9.0.314"},
+        {"name": "v10.0.300"},
+    ]
+
+    # Unstable / unrelated tags
+    unstable_tags: List[JsonObject] = [
+        {"name": "v11.0.100-preview.4.26230.115"},
+        {"name": "v10.0.100-rc.1.25451.107"},
+        {"name": "v8.0"},  # only two components
+        {"name": "8.0.100"},  # missing v prefix
+        {"name": ""},  # empty name
+    ]
+
+    # Test stable tags
+    for tag in stable_tags:
+        assert dotnet_fetcher._is_stable_tag(tag) is True
+
+    # Test unstable tags
+    for tag in unstable_tags:
+        assert dotnet_fetcher._is_stable_tag(tag) is False
+
+
+def test_parse_version_from_tag(dotnet_fetcher: DotnetVersionFetcher) -> None:
+    """Test _parse_version_from_tag method"""
+    # Valid tag
+    valid_tag: JsonObject = {
+        "name": "v8.0.100",
+        "commit": {"sha": "abc123"},
+        "tarball_url": "https://example.com/tarball",
+        "zipball_url": "https://example.com/zipball",
+    }
+
+    release_info: ReleaseInfo = dotnet_fetcher._parse_version_from_tag(valid_tag)
+
+    assert release_info.version == "8.0.100"
+    assert release_info.prerelease is False
+    assert release_info.additional_info["tag_name"] == "v8.0.100"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
+    assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
+    assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
+
+    # Invalid tag (no name)
+    with pytest.raises(ParseError):
+        dotnet_fetcher._parse_version_from_tag({"name": ""})
+
+
+def test_get_stability_criteria(dotnet_fetcher: DotnetVersionFetcher) -> None:
+    """Test _get_stability_criteria method (stable = previous major)"""
+    # Prepare sample releases (newest first)
+    releases: List[ReleaseInfo] = [
+        ReleaseInfo(version="10.0.300"),
+        ReleaseInfo(version="10.0.108"),
+        ReleaseInfo(version="9.0.314"),
+        ReleaseInfo(version="8.0.421"),
+    ]
+
+    latest, stable = dotnet_fetcher._get_stability_criteria(releases)
+
+    assert latest.version == "10.0.300"
+    assert stable.version == "9.0.314"
+
+    # Case with single release
+    single_release: List[ReleaseInfo] = [ReleaseInfo(version="10.0.300")]
+    latest, stable = dotnet_fetcher._get_stability_criteria(single_release)
+
+    assert latest.version == "10.0.300"
+    assert stable.version == "10.0.300"
+
+    # Empty releases case
+    with pytest.raises(ValueError):
+        dotnet_fetcher._get_stability_criteria([])
+
+
+def test_dotnet_filter_func() -> None:
+    """Test dotnet_filter_func with various tag names"""
+    # Stable tags
+    stable_tags: List[JsonObject] = [
+        {"name": "v8.0.100"},
+        {"name": "v9.0.314"},
+        {"name": "v10.0.300"},
+    ]
+
+    # Unstable / unrelated tags
+    unstable_tags: List[JsonObject] = [
+        {"name": "v11.0.100-preview.4.26230.115"},
+        {"name": "v10.0.100-rc.1.25451.107"},
+        {"name": "v8.0"},
+        {"name": "latest"},
+        {"name": ""},
+    ]
+
+    # Test stable tags
+    for tag in stable_tags:
+        assert dotnet_filter_func(tag) is True
+
+    # Test unstable tags
+    for tag in unstable_tags:
+        assert dotnet_filter_func(tag) is False
+
+
+def test_fetch_versions_integration(
+    dotnet_fetcher: DotnetVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """
+    Test fetch_versions method with mocked API calls
+    """
+    # Prepare mock tags
+    mock_tags: List[JsonObject] = [
+        {
+            "name": "v10.0.300",
+            "commit": {"sha": "abc123"},
+            "tarball_url": "https://example.com/tarball/10.0.300",
+            "zipball_url": "https://example.com/zipball/10.0.300",
+        },
+        {
+            "name": "v9.0.314",
+            "commit": {"sha": "def456"},
+            "tarball_url": "https://example.com/tarball/9.0.314",
+            "zipball_url": "https://example.com/zipball/9.0.314",
+        },
+    ]
+
+    # Mock _get_github_tags method to return predefined tags
+    mocker.patch.object(dotnet_fetcher, "_get_github_tags", return_value=mock_tags)
+
+    # Fetch versions
+    versions = dotnet_fetcher.fetch_versions(recent_count=2)
+
+    # Validate results
+    assert versions.latest == "10.0.300"
+    assert versions.stable == "9.0.314"
+    assert len(versions.recent_releases) == 2
+
+    # Check details
+    assert "fetch_time" in versions.details
+    assert versions.details["source"] == "github:dotnet/sdk"
+    assert "latest_info" in versions.details
+    assert "stable_info" in versions.details
+
+
+def test_get_stability_criteria_invalid_latest_version(
+    dotnet_fetcher: DotnetVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria when the latest version is unparsable"""
+    # Mock logger
+    mocker.patch.object(dotnet_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="invalid"),  # latest does not match the semver regex
+        ReleaseInfo(version="9.0.314"),
+    ]
+
+    latest, stable = dotnet_fetcher._get_stability_criteria(releases)
+
+    # When latest cannot be parsed, it falls back to using latest as stable
+    assert latest.version == "invalid"
+    assert stable.version == "invalid"
+
+
+def test_get_stability_criteria_no_previous_major(
+    dotnet_fetcher: DotnetVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria when no previous major version exists"""
+    # Mock logger
+    mocker.patch.object(dotnet_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="10.0.300"),
+        ReleaseInfo(version="10.0.108"),  # Same major version
+    ]
+
+    latest, stable = dotnet_fetcher._get_stability_criteria(releases)
+
+    assert latest.version == "10.0.300"
+    assert stable.version == "10.0.300"  # Use latest as no previous major exists
+
+
+def test_get_stability_criteria_invalid_release_version(
+    dotnet_fetcher: DotnetVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria with an invalid version in the releases list"""
+    # Mock logger
+    mocker.patch.object(dotnet_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="10.0.300"),
+        ReleaseInfo(version="9.0.invalid"),  # Does not match regex, must be skipped
+        ReleaseInfo(version="9.0.314"),
+    ]
+
+    latest, stable = dotnet_fetcher._get_stability_criteria(releases)
+
+    assert latest.version == "10.0.300"
+    assert stable.version == "9.0.314"  # Skip invalid and select correct stable version

--- a/tests/version/test_registry.py
+++ b/tests/version/test_registry.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from json2vars_setter.version.fetchers.dotnet import DotnetVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
 from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
 from json2vars_setter.version.fetchers.php import PhpVersionFetcher
@@ -19,6 +20,7 @@ def test_get_version_fetcher_returns_expected_type() -> None:
     assert isinstance(get_version_fetcher("go"), GoVersionFetcher)
     assert isinstance(get_version_fetcher("rust"), RustVersionFetcher)
     assert isinstance(get_version_fetcher("php"), PhpVersionFetcher)
+    assert isinstance(get_version_fetcher("dotnet"), DotnetVersionFetcher)
 
 
 def test_get_version_fetcher_unsupported_language() -> None:


### PR DESCRIPTION
## Summary

Add **.NET (C#)** as a supported language (Tier 1). SDK versions are fetched from the
`dotnet/sdk` tags (the same GitHub-tags approach as the other languages). Includes the
full repo structure: fetcher, action contract, tests, example project, CI workflow,
status badge, and docs.

Closes #506

## Changes

### Core
- **`version/fetchers/dotnet.py`**: `DotnetVersionFetcher` (`dotnet/sdk`) + `dotnet_filter_func`
  - Stable detection: tag fully matches `vX.Y.Z` (`v11.0.100-preview.4...`,
    `v10.0.100-rc.1...` are excluded)
  - The .NET SDK minor is always `0`, so the meaningful release line is the **major**
    version (8.0, 9.0, 10.0); `stable` = newest SDK of the previous major
- **`version/registry.py`**: register `"dotnet"` in `LANGUAGE_FETCHERS`
- **`features/matrix_update.py`**: `--dotnet` strategy arg (+ `--all` / `main()` wiring)
- **`action.yml`**: `dotnet-strategy` input, `versions_dotnet` output, strategy arg, summary

### Tests (100% coverage)
- `tests/version/fetchers/test_dotnet.py` (covers `dotnet.py` fully)
- `tests/version/test_registry.py`, `tests/features/test_matrix_update.py` updates

### Example project & CI
- `examples/dotnet/`: xUnit JSON-parser sample (`JsonParser.cs`, `JsonParserTests.cs`,
  `JsonParserExample.csproj`, `dotnet_project_matrix.json`, README). Targets `net8.0`
  with `RollForward=LatestMajor` so the same assembly runs on every SDK in the matrix.
- `.github/workflows/dotnet_test.yml`: `set_variables` -> `run_tests` (OS x .NET matrix
  via `actions/setup-dotnet`) -> `update_badge` (dedicated gist)

### Badges & docs
- `README.md` / `docs/index.md`: .NET status badge row (gist `dotnet-test-badge.json`)
  + supported-languages prose
- `docs/reference/options.md`, `docs/features/dynamic-update.md`,
  `docs/features/index.md`, `CLAUDE.md`

## Action interface

.NET uses the **same action interface as every other language**: input
`dotnet-strategy`, output `versions_dotnet` (language key `dotnet`). The only
.NET-specific parts live outside this action: the consumer uses `actions/setup-dotnet`,
and the example matrix uses channel versions (`"8.0"`, `"9.0"`) that setup-dotnet accepts.

## Verification

| Check | Result |
|---|---|
| `mypy --config-file=pyproject.toml` | Pass (41 files, strict + no-Any) |
| `ruff check` / `ruff format --check` | Pass |
| `pytest` + coverage | 224 passed, 100% coverage (`dotnet.py` 100%) |

## Release ordering (two-phase action reference)

`dotnet_test.yml` uses `uses: ./` so it tests the PR code and is green now (`versions_dotnet`
is not in any published tag yet). **Follow-up after the .NET release:** switch it to the
pinned tag `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other `*_test.yml`
workflows (tracked via a `TODO` and CLAUDE.md "Adding a New Language" point 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)