### PR TITLE
:pushpin: Pin dotnet_test.yml to json2vars-setter@v1.5.0

### DIFF
--- a/.github/workflows/dotnet_test.yml
+++ b/.github/workflows/dotnet_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds .NET): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.5.0
         with:
           json-file: examples/dotnet/dotnet_project_matrix.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,13 @@ or the addition is incomplete:
 
 - **Commit messages**: Follow [gitmoji](https://gitmoji.dev/) conventions. Releases are automated by **semantic-release-gitmoji**, which reads the gitmoji to pick the next version: `:boom:` → major, `:sparkles:` → minor, and fixes/maintenance (`:bug:`, `:lock:`, `:ambulance:`, `:zap:`, `:wrench:`, `:recycle:`, `:arrow_up:`, …) → patch. Other gitmoji (e.g. `:memo:`, `:art:`, `:white_check_mark:`) don't trigger a release. The full mapping is the `releaseRules` in `.releaserc.json`.
 - **Branch naming**: Use prefixes: `feature-`, `bugfix-`, `docs-`, `refactor-`
+- **GitHub Actions selection**: Prefer **official** actions (the `actions/*` org, or the
+  language's first-party action such as `ruby/setup-ruby`, `actions/setup-dotnet`,
+  `actions/setup-java`). When no official action exists, use a widely-adopted,
+  actively-maintained third-party action (highest usage / trending), e.g.
+  `shivammathur/setup-php` for PHP. Pin every `uses:` to a commit SHA with the version
+  tag as a trailing comment (except the `7rikazhexde/json2vars-setter@vX.Y.Z`
+  self-reference, which the Versioning Rule keeps as a tag).
 - **Python version**: 3.10+ (target 3.12 for mypy)
 - **Linting**: Ruff with E, F, I rules (E402 and E501 ignored)
 - **Type checking**: mypy with strict settings (`disallow_untyped_defs`, `warn_return_any`)


### PR DESCRIPTION
## Summary

.NET support shipped in **v1.5.0**, so the published tag now exposes `versions_dotnet`.
Switch `dotnet_test.yml` from the in-repo `uses: ./` to the pinned release tag
`uses: 7rikazhexde/json2vars-setter@v1.5.0`.

This completes the documented two-phase action reference for a new language
(see CLAUDE.md "Adding a New Language", point 9): `uses: ./` on the introducing PR
to stay green before release, then the pinned tag afterwards so it matches every
other `*_test.yml` and the Versioning Rule. From here on `sync-version-refs.sh`
keeps it pinned to the latest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)