### PR TITLE
:sparkles: Add Java version support

### DIFF
--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -1,0 +1,165 @@
+name: Java Test
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'examples/java/**'
+      - '.github/workflows/java_test.yml'
+
+jobs:
+  set_variables:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.json2vars.outputs.os }}
+      versions_java: ${{ steps.json2vars.outputs.versions_java }}
+      ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set variables from JSON
+        id: json2vars
+        # Use the in-repo action so this workflow tests the current code. A new
+        # language's `versions_<lang>` output does not exist in the published tag
+        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
+        # until then; `./` keeps the example workflow green from the first PR.
+        # TODO(after the release that adds Java): switch to the pinned tag
+        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
+        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
+        uses: ./
+        with:
+          json-file: examples/java/java_project_matrix.json
+
+      - name: Debug output values
+        run: |
+          echo "os: ${{ steps.json2vars.outputs.os }}"
+          echo "os[0]: ${{ fromJson(steps.json2vars.outputs.os)[0] }}"
+          echo "os[1]: ${{ fromJson(steps.json2vars.outputs.os)[1] }}"
+          echo "os[2]: ${{ fromJson(steps.json2vars.outputs.os)[2] }}"
+          echo "versions_java: ${{ steps.json2vars.outputs.versions_java }}"
+          echo "versions_java[0]: ${{ fromJson(steps.json2vars.outputs.versions_java)[0] }}"
+          echo "versions_java[1]: ${{ fromJson(steps.json2vars.outputs.versions_java)[1] }}"
+          echo "versions_java[2]: ${{ fromJson(steps.json2vars.outputs.versions_java)[2] }}"
+          echo "ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}"
+
+  run_tests:
+    needs: set_variables
+    strategy:
+      # Run every matrix combination even if one fails so the aggregated job
+      # result reflects the status of the whole matrix (used by the badge).
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.set_variables.outputs.os) }}
+        java-version: ${{ fromJson(needs.set_variables.outputs.versions_java) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+          cache: 'maven'
+
+      - name: Set timezone
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
+        with:
+          timezoneLinux: "Asia/Tokyo"
+          timezoneMacos: "Asia/Tokyo"
+          timezoneWindows: "Tokyo Standard Time"
+
+      - name: Display Java version
+        run: |
+          java -version
+          mvn --version
+
+      - name: Show matrix
+        shell: bash
+        run: |
+          # For non-list case
+          ghpages_branch="${{ needs.set_variables.outputs.ghpages_branch }}"
+
+          # For list case, explicitly enclose the list in "" to make it a string. (Note that it is not ''.)
+          os='${{ needs.set_variables.outputs.os }}'
+          versions_java='${{ needs.set_variables.outputs.versions_java }}'
+
+          # For list index case
+          os_0="${{ fromJson(needs.set_variables.outputs.os)[0] }}"
+          os_1="${{ fromJson(needs.set_variables.outputs.os)[1] }}"
+          os_2="${{ fromJson(needs.set_variables.outputs.os)[2] }}"
+
+          versions_java_0="${{ fromJson(needs.set_variables.outputs.versions_java)[0] }}"
+          versions_java_1="${{ fromJson(needs.set_variables.outputs.versions_java)[1] }}"
+          versions_java_2="${{ fromJson(needs.set_variables.outputs.versions_java)[2] }}"
+
+          echo "os: ${os}"
+          echo "os_0: ${os_0}"
+          echo "os_1: ${os_1}"
+          echo "os_2: ${os_2}"
+          echo "versions_java: ${versions_java}"
+          echo "versions_java_0: ${versions_java_0}"
+          echo "versions_java_1: ${versions_java_1}"
+          echo "versions_java_2: ${versions_java_2}"
+          echo "ghpages_branch: ${ghpages_branch}"
+
+          # For loop case
+          os_list=$(echo "${os}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          java_versions_list=$(echo "${versions_java}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+
+          for current_os in ${os_list}; do
+            for version in ${java_versions_list}; do
+              echo "Current OS: ${current_os}, Current Java Version: ${version}"
+            done
+          done
+
+      - name: Run tests
+        id: java_test
+        working-directory: ./examples/java
+        shell: bash
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
+        run: |
+          mvn -B test
+
+  update_badge:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Determine status and color
+        id: status
+        shell: bash
+        run: |
+          # needs.run_tests.result aggregates every matrix combination:
+          # 'success' only when all passed, 'failure' if any leg failed.
+          case "${{ needs.run_tests.result }}" in
+            success)   status=passing;   color=2ea44f ;;
+            failure)   status=failing;   color=cf222e ;;
+            cancelled) status=cancelled; color=808080 ;;
+            skipped)   status=skipped;   color=808080 ;;
+            *)         status=pending;   color=dbab09 ;;
+          esac
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
+
+      - name: Create badge
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 813e5201a834d06253014b66ee8fd154
+          filename: java-test-badge.json
+          label: Java Test
+          message: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          labelColor: "24292f"
+          style: "flat"
+          namedLogo: "github"
+          logoColor: "white"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, PHP, and .NET (C#). The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
+json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, PHP, .NET (C#), and Java. The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
 
 ## Common Commands
 
@@ -79,7 +79,7 @@ A pluggable architecture for fetching language versions from GitHub:
 - **`version/core/base.py`** — `BaseVersionFetcher` abstract class handles GitHub API pagination, authentication (via `GITHUB_TOKEN`), and defines the interface (`_is_stable_tag()`, `_parse_version_from_tag()`)
 - **`version/core/exceptions.py`** — Exception hierarchy: `VersionFetchError` → `GitHubAPIError`, `ParseError`, `ValidationError`
 - **`version/core/utils.py`** — Shared data classes (`VersionInfo`, `ReleaseInfo`) and helpers
-- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`, `dotnet.py`), each parsing tags from the respective GitHub repository
+- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`, `dotnet.py`, `java.py`). Most parse tags from the respective GitHub repository; `java.py` is the exception — it overrides `fetch_versions` to query the Adoptium API (see `docs/reference/version-sources.md`)
 
 ### Entry Points
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, and .NET (C#)
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), and Java
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -40,6 +40,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![Rust](https://img.shields.io/badge/Rust-000000?style=flat&logo=rust&logoColor=white) | [![rust-toolchain](https://img.shields.io/badge/rust--toolchain-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/rustup-toolchain-install) | [![Rust Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5e160d06cfffd42a8f0e4ae6e8e8f025/raw/rust-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/rust_test.yml) |
 | ![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat&logo=php&logoColor=white) | [![setup-php](https://img.shields.io/badge/setup--php-777BB4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-php-action) | [![PHP Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/a9bc428c9f5a2f998bd7307038e557e1/raw/php-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/php_test.yml) |
 | ![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white) | [![setup-dotnet](https://img.shields.io/badge/setup--dotnet-512BD4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-dotnet) | [![.NET Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/33c8a05d3ed6c038877d847ffc12b2f9/raw/dotnet-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/dotnet_test.yml) |
+| ![Java](https://img.shields.io/badge/Java-007396?style=flat&logo=openjdk&logoColor=white) | [![setup-java](https://img.shields.io/badge/setup--java-007396?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-java-jdk) | [![Java Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/813e5201a834d06253014b66ee8fd154/raw/java-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/java_test.yml) |
 
 ## Quick Start
 

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,9 @@ inputs:
   dotnet-strategy:
     description: 'Update strategy for .NET (C#) versions (stable, latest, or both)'
     required: false  # Optional
+  java-strategy:
+    description: 'Update strategy for Java versions (stable, latest, or both)'
+    required: false  # Optional
 
   # Safe Mode
   dry-run:
@@ -138,6 +141,9 @@ outputs:
   versions_dotnet:
     description: 'List of .NET (C#) versions'
     value: ${{ steps.set_outputs.outputs.versions_dotnet }}
+  versions_java:
+    description: 'List of Java versions'
+    value: ${{ steps.set_outputs.outputs.versions_java }}
   ghpages_branch:
     description: 'GitHub Pages branch'
     value: ${{ steps.set_outputs.outputs.ghpages_branch }}
@@ -207,6 +213,9 @@ runs:
           fi
           if [[ -n "${{ inputs.dotnet-strategy }}" ]]; then
             ARGS+=("--dotnet" "${{ inputs.dotnet-strategy }}")
+          fi
+          if [[ -n "${{ inputs.java-strategy }}" ]]; then
+            ARGS+=("--java" "${{ inputs.java-strategy }}")
           fi
         fi
 
@@ -328,4 +337,5 @@ runs:
         echo "Rust Versions: ${{ steps.set_outputs.outputs.versions_rust }}"
         echo "PHP Versions: ${{ steps.set_outputs.outputs.versions_php }}"
         echo ".NET Versions: ${{ steps.set_outputs.outputs.versions_dotnet }}"
+        echo "Java Versions: ${{ steps.set_outputs.outputs.versions_java }}"
         echo "GitHub Pages Branch: ${{ steps.set_outputs.outputs.ghpages_branch }}"

--- a/docs/features/dynamic-update.md
+++ b/docs/features/dynamic-update.md
@@ -194,6 +194,7 @@ The Dynamic Matrix Updater accepts the following inputs:
 | `rust-strategy` | Strategy for Rust versions | No | - |
 | `php-strategy` | Strategy for PHP versions | No | - |
 | `dotnet-strategy` | Strategy for .NET (C#) versions | No | - |
+| `java-strategy` | Strategy for Java versions | No | - |
 | `dry-run` | Run without updating the file | No | `'false'` |
 
 ## How It Works
@@ -246,6 +247,7 @@ The Dynamic Matrix Updater currently supports:
 - **Rust**: Fetches from Rust releases via GitHub API
 - **PHP**: Fetches from PHP releases via GitHub API
 - **.NET (C#)**: Fetches from .NET SDK releases via GitHub API
+- **Java**: Fetches from the Adoptium API (latest feature release / latest LTS)
 
 ## Best Practices
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -109,7 +109,7 @@ graph LR
 - **Automated Version Updates**: Keep testing matrices current without manual intervention
 - **Efficient API Usage**: Reduce external API calls by caching version information
 - **Cross-Platform Testing**: Define operating systems and language versions for comprehensive testing
-- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, PHP, and .NET (C#) in a single configuration
+- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), and Java in a single configuration
 
 ## Component Integration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, and .NET (C#)
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), and Java
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -27,6 +27,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![Rust](https://img.shields.io/badge/Rust-000000?style=flat&logo=rust&logoColor=white) | [![rust-toolchain](https://img.shields.io/badge/rust--toolchain-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/rustup-toolchain-install) | [![Rust Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5e160d06cfffd42a8f0e4ae6e8e8f025/raw/rust-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/rust_test.yml) |
 | ![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat&logo=php&logoColor=white) | [![setup-php](https://img.shields.io/badge/setup--php-777BB4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-php-action) | [![PHP Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/a9bc428c9f5a2f998bd7307038e557e1/raw/php-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/php_test.yml) |
 | ![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white) | [![setup-dotnet](https://img.shields.io/badge/setup--dotnet-512BD4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-dotnet) | [![.NET Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/33c8a05d3ed6c038877d847ffc12b2f9/raw/dotnet-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/dotnet_test.yml) |
+| ![Java](https://img.shields.io/badge/Java-007396?style=flat&logo=openjdk&logoColor=white) | [![setup-java](https://img.shields.io/badge/setup--java-007396?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-java-jdk) | [![Java Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/813e5201a834d06253014b66ee8fd154/raw/java-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/java_test.yml) |
 
 ## Quick Start
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -23,6 +23,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `rust-strategy` | Update strategy for Rust versions | ✗ | - | Same valid values as `update-strategy` |
 | `php-strategy` | Update strategy for PHP versions | ✗ | - | Same valid values as `update-strategy` |
 | `dotnet-strategy` | Update strategy for .NET (C#) versions | ✗ | - | Same valid values as `update-strategy` |
+| `java-strategy` | Update strategy for Java versions | ✗ | - | Same valid values as `update-strategy` |
 | `dry-run` | Run in dry-run mode without updating the JSON file | ✗ | `false` | For testing update strategies |
 
 ### Cache Version Options
@@ -54,6 +55,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `versions_rust` | List of Rust versions | `["1.70.0", "1.71.0", "stable"]` |
 | `versions_php` | List of PHP versions | `["8.2.0", "8.3.0", "8.4.0"]` |
 | `versions_dotnet` | List of .NET (C#) versions | `["8.0.100", "9.0.100"]` |
+| `versions_java` | List of Java versions | `["21", "17", "11"]` |
 | `ghpages_branch` | GitHub Pages branch name | `"gh-pages"` |
 
 ## Usage Notes

--- a/docs/reference/version-sources.md
+++ b/docs/reference/version-sources.md
@@ -1,0 +1,136 @@
+# Version Sources
+
+This page documents, for every supported language, **where json2vars-setter fetches
+versions from**, which candidate sources were considered, **why** the chosen source was
+picked, and the language-specific characteristics that follow from it.
+
+## How fetching works
+
+Each language has a fetcher under `json2vars_setter/version/fetchers/`. Most fetchers
+extend `BaseVersionFetcher`, which reads **Git tags from a GitHub repository** via the
+GitHub REST API, filters them to stable releases, and derives:
+
+- **`latest`** — the most recent stable release
+- **`stable`** — a "known-good" release (usually the previous minor/major line)
+- **`recent_releases`** — the most recent stable releases (used by the cache feature)
+
+A language whose versions are not cleanly expressed as a single repo's tags (currently
+**Java**) overrides `fetch_versions` and queries an official API instead.
+
+The dynamic-update strategies map onto these fields:
+
+- `stable` → `[stable]`
+- `latest` → `[latest]`
+- `both` → `[stable, latest]`
+
+> The **example matrices** under `examples/<lang>/` are hand-curated to the version
+> format the language's `setup-*` action expects, which may differ from the raw
+> fetcher output (e.g. major-only vs full `X.Y.Z`).
+
+## Summary
+
+| Language | Source | `latest` | `stable` | setup action |
+|----------|--------|----------|----------|--------------|
+| Python | `python/cpython` tags | newest stable | previous minor | `actions/setup-python` |
+| Node.js | `nodejs/node` tags + LTS metadata | newest stable | newest **LTS** | `actions/setup-node` |
+| Ruby | `ruby/ruby` tags | newest stable | previous minor | `ruby/setup-ruby` |
+| Go | `golang/go` tags | newest stable | previous minor | `actions/setup-go` |
+| Rust | `rust-lang/rust` tags + channel info | newest stable | previous minor | `dtolnay`/rustup toolchain |
+| PHP | `php/php-src` tags | newest stable | previous minor | `shivammathur/setup-php` |
+| .NET (C#) | `dotnet/sdk` tags | newest SDK | previous **major** | `actions/setup-dotnet` |
+| Java | **Adoptium API** | newest **feature** | newest **LTS** | `actions/setup-java` |
+
+## Per-language details
+
+### Python — `python/cpython`
+
+- **Source:** tags of the official CPython repository (`vX.Y.Z`).
+- **Why:** CPython is the reference implementation; its tags are the canonical version
+  list. Direct fit for the GitHub-tags fetcher.
+- **Characteristics:** pre-releases (`a`/`b`/`rc`) are excluded; `stable` is the previous
+  minor line of `latest`.
+
+### Node.js — `nodejs/node`
+
+- **Source:** tags of the official Node.js repository, **plus LTS metadata** to identify
+  Long-Term-Support lines.
+- **Candidates:** plain tags only (rejected — Node's notion of "stable" is the current
+  **LTS**, which tags alone don't convey).
+- **Why:** Node users target LTS releases, so `stable` is resolved to the most recent LTS
+  rather than simply the previous minor.
+
+### Ruby — `ruby/ruby`
+
+- **Source:** tags of the official Ruby repository (underscore form, e.g. `v3_4_2`).
+- **Why:** canonical source; clean fit for the GitHub-tags fetcher.
+- **Characteristics:** pre-release suffixes are excluded; `stable` is the previous minor.
+
+### Go — `golang/go`
+
+- **Source:** tags of the official Go repository (`goX.Y.Z`).
+- **Why:** canonical source; clean fit.
+- **Characteristics:** the `go` prefix is stripped; `rc`/`beta` builds are excluded;
+  `stable` is the previous minor.
+
+### Rust — `rust-lang/rust`
+
+- **Source:** tags of the official Rust repository (`1.XX.Y`), **plus channel info** from
+  `static.rust-lang.org`.
+- **Why:** canonical source; channel info documents the `stable`/`beta`/`nightly`
+  availability alongside the concrete version.
+
+### PHP — `php/php-src`
+
+- **Source:** tags of the official PHP source repository (`php-X.Y.Z`).
+- **Candidates:** none better — there is no official "setup-php" from GitHub, but the
+  source repo's tags are authoritative for versions.
+- **Why:** clean fit for the GitHub-tags fetcher.
+- **Characteristics:** only tags matching `php-X.Y.Z` exactly are kept (`...RC1`,
+  `...beta1`, `...alpha1`, and unrelated tags like `yaf-*` are excluded); `stable` is the
+  previous minor. The consumer side uses `shivammathur/setup-php` (the de-facto standard,
+  since no official action exists).
+
+### .NET (C#) — `dotnet/sdk`
+
+- **Source:** tags of the official .NET SDK repository (`vX.Y.Z`, e.g. `v8.0.100`).
+- **Candidates considered:**
+    - **`dotnet/sdk` tags** (chosen) — consistent with the other languages' GitHub-tags
+      approach.
+    - **`releases-index.json`** release metadata (not chosen) — richer (LTS/STS, support
+      phase, per-channel latest), but diverges from the common fetcher pattern.
+- **Why:** keeps .NET on the same simple, consistent GitHub-tags mechanism as the other
+  languages.
+- **Characteristics:** the SDK **minor is always `0`**, so the meaningful release line is
+  the **major** (8.0, 9.0, 10.0). `latest` is the newest SDK; `stable` is the newest SDK
+  of the **previous major**. `preview`/`rc` tags are excluded. Example matrices use the
+  channel form (`"8.0"`, `"9.0"`) that `actions/setup-dotnet` accepts.
+
+### Java — Adoptium API
+
+- **Source:** the **Adoptium API** `GET /v3/info/available_releases`.
+- **Candidates considered:**
+    - **`openjdk/jdk` tags** (rejected) — that repository carries only **early-access
+      builds of the in-development release** (e.g. `jdk-28+0`); GA and LTS lines live in
+      separate update repositories, so a single repo's tags cannot represent stable Java
+      versions.
+    - **`openjdk/jdkXXu` update repos** (rejected) — would require juggling many
+      repositories and still mixes build metadata.
+    - **Adoptium API** (chosen) — a single authoritative endpoint that reports
+      `available_releases`, `available_lts_releases`, `most_recent_feature_release`, and
+      `most_recent_lts`.
+- **Why:** it is the only clean, single-source way to enumerate real, installable Java
+  versions and to distinguish LTS from feature releases.
+- **Characteristics:** this is the **only fetcher that does not use GitHub tags** — it
+  overrides `fetch_versions`. `latest` = most recent **feature** release (e.g. `26`);
+  `stable` = most recent **LTS** (e.g. `25`); `recent_releases` = the available **LTS**
+  releases, newest first. The consumer side uses the official `actions/setup-java` with
+  the `temurin` distribution; example matrices use major versions (`"11"`, `"17"`,
+  `"21"`).
+
+## Adding another language
+
+See the **"Adding a New Language"** checklist in `CLAUDE.md` for the full set of files to
+touch (fetcher, registry, action contract, tests, example, workflow, badges, docs). When
+choosing a version source, prefer the language's **canonical GitHub repository tags**;
+if those don't cleanly express installable releases (as with Java), use the official
+project API and override `fetch_versions`.

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,0 +1,57 @@
+# Java Example for json2vars-setter
+
+This is a Java implementation example for parsing JSON configuration files in
+GitHub Actions matrix testing.
+
+## Requirements
+
+- JDK 11 or newer
+- Maven
+
+## Project Structure
+
+```bash
+.
+├── pom.xml                                              # Maven build + dependencies
+├── java_project_matrix.json                            # Matrix definition
+└── src
+    ├── main/java/io/github/json2varssetter/JsonParser.java       # Main implementation
+    └── test/java/io/github/json2varssetter/JsonParserTest.java   # Test implementation
+```
+
+## Setup & Running
+
+Run the tests with Maven:
+
+```bash
+cd examples/java
+mvn -B test
+```
+
+## Matrix file
+
+`java_project_matrix.json` defines the OS list and Java versions used by the matrix
+testing workflow. The versions use the major form accepted by
+[`actions/setup-java`](https://github.com/marketplace/actions/setup-java-jdk)
+(distribution `temurin`):
+
+```json
+{
+    "os": ["ubuntu-latest", "windows-latest", "macos-latest"],
+    "versions": {
+        "java": ["11", "17", "21"]
+    },
+    "ghpages_branch": "ghgapes"
+}
+```
+
+The project targets Java 11 bytecode (`maven.compiler.release=11`), so the same code
+builds and runs on every JDK in the matrix. The `.github/workflows/java_test.yml`
+workflow reads this file through json2vars-setter and runs the tests across every
+OS / Java version combination.
+
+> Note: json2vars-setter's dynamic version fetcher sources Java versions from the
+> [Adoptium API](https://api.adoptium.net/) (`latest` = newest feature release,
+> `stable` = newest LTS), because OpenJDK GA/LTS versions are not cleanly available
+> from a single GitHub repository's tags. See the
+> [Version Sources reference](../../docs/reference/version-sources.md) for details.

--- a/examples/java/java_project_matrix.json
+++ b/examples/java/java_project_matrix.json
@@ -1,0 +1,15 @@
+{
+    "os": [
+        "ubuntu-latest",
+        "windows-latest",
+        "macos-latest"
+    ],
+    "versions": {
+        "java": [
+            "11",
+            "17",
+            "21"
+        ]
+    },
+    "ghpages_branch": "ghgapes"
+}

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.github.json2varssetter</groupId>
+  <artifactId>java-example</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit.version>5.10.2</junit.version>
+    <jackson.version>2.17.2</jackson.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/java/src/main/java/io/github/json2varssetter/JsonParser.java
+++ b/examples/java/src/main/java/io/github/json2varssetter/JsonParser.java
@@ -1,0 +1,44 @@
+package io.github.json2varssetter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Minimal JSON configuration parser used to demonstrate consuming the
+ * json2vars-setter matrix file in a Java project.
+ */
+public final class JsonParser {
+
+    private JsonParser() {
+    }
+
+    /**
+     * Parse a JSON configuration file into a JsonNode tree.
+     *
+     * @param filePath path to the JSON file
+     * @return the parsed tree, or {@code null} on failure
+     */
+    public static JsonNode parseConfig(String filePath) {
+        return parseConfig(filePath, false);
+    }
+
+    /**
+     * Parse a JSON configuration file into a JsonNode tree.
+     *
+     * @param filePath path to the JSON file
+     * @param silent   when true, suppress error output
+     * @return the parsed tree, or {@code null} on failure
+     */
+    public static JsonNode parseConfig(String filePath, boolean silent) {
+        try {
+            return new ObjectMapper().readTree(new File(filePath));
+        } catch (IOException e) {
+            if (!silent) {
+                System.err.println("Error reading or parsing JSON: " + e.getMessage());
+            }
+            return null;
+        }
+    }
+}

--- a/examples/java/src/test/java/io/github/json2varssetter/JsonParserTest.java
+++ b/examples/java/src/test/java/io/github/json2varssetter/JsonParserTest.java
@@ -1,0 +1,44 @@
+package io.github.json2varssetter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+class JsonParserTest {
+
+    private final String configPath =
+        Paths.get("java_project_matrix.json").toString();
+
+    @Test
+    void parsesJsonFile() {
+        JsonNode result = JsonParser.parseConfig(configPath);
+        assertNotNull(result);
+    }
+
+    @Test
+    void parsesExpectedValues() {
+        JsonNode result = JsonParser.parseConfig(configPath);
+        assertNotNull(result);
+
+        JsonNode os = result.get("os");
+        assertTrue(os.toString().contains("ubuntu-latest"));
+        assertTrue(os.toString().contains("windows-latest"));
+        assertTrue(os.toString().contains("macos-latest"));
+
+        JsonNode versions = result.get("versions").get("java");
+        assertEquals("[\"11\",\"17\",\"21\"]", versions.toString());
+
+        assertEquals("ghgapes", result.get("ghpages_branch").asText());
+    }
+
+    @Test
+    void returnsNullForMissingFile() {
+        JsonNode result = JsonParser.parseConfig("non-existent.json", true);
+        assertNull(result);
+    }
+}

--- a/json2vars_setter/features/matrix_update.py
+++ b/json2vars_setter/features/matrix_update.py
@@ -275,6 +275,11 @@ Examples:
         help="Strategy for .NET (C#) versions",
     )
     parser.add_argument(
+        "--java",
+        choices=["stable", "latest", "both"],
+        help="Strategy for Java versions",
+    )
+    parser.add_argument(
         "--all",
         choices=["stable", "latest", "both"],
         help="Apply the same strategy to all languages",
@@ -309,6 +314,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         args.rust = args.all
         args.php = args.all
         args.dotnet = args.all
+        args.java = args.all
 
     # Collect language strategies
     language_strategies: Dict[str, str] = {}
@@ -326,6 +332,8 @@ def main(argv: Optional[List[str]] = None) -> None:
         language_strategies["php"] = args.php
     if args.dotnet:
         language_strategies["dotnet"] = args.dotnet
+    if args.java:
+        language_strategies["java"] = args.java
 
     if not language_strategies:
         parser.error("At least one language strategy must be specified")

--- a/json2vars_setter/version/fetchers/java.py
+++ b/json2vars_setter/version/fetchers/java.py
@@ -1,0 +1,129 @@
+from typing import List, cast
+
+from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.core.utils import (
+    JsonObject,
+    ReleaseInfo,
+    VersionInfo,
+    get_utc_now,
+    setup_logging,
+)
+
+# Java (OpenJDK) GA/LTS releases are not cleanly represented by a single GitHub
+# repository's tags (openjdk/jdk only carries early-access builds of the in-development
+# release, and GA/LTS lines live in separate update repositories). The Adoptium API
+# is the authoritative, clean source for "which Java versions are available".
+ADOPTIUM_API_BASE = "https://api.adoptium.net/v3"
+
+
+class JavaVersionFetcher(BaseVersionFetcher):
+    """Fetches Java (Temurin/Adoptium) version information from the Adoptium API"""
+
+    def __init__(self) -> None:
+        """Initialize with the Adoptium API endpoint"""
+        # The base class wires up an authenticated requests session; the github
+        # owner/repo are unused because this fetcher overrides ``fetch_versions``
+        # and talks to the Adoptium API rather than the GitHub tags endpoint.
+        super().__init__("adoptium", "temurin")
+        self.available_releases_url = f"{ADOPTIUM_API_BASE}/info/available_releases"
+
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
+        """Not used: JavaVersionFetcher uses the Adoptium API, not GitHub tags."""
+        raise NotImplementedError("JavaVersionFetcher uses the Adoptium API, not tags")
+
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
+        """Not used: JavaVersionFetcher uses the Adoptium API, not GitHub tags."""
+        raise NotImplementedError("JavaVersionFetcher uses the Adoptium API, not tags")
+
+    def fetch_versions(self, recent_count: int = 5) -> VersionInfo:
+        """
+        Fetch Java version information from the Adoptium API
+
+        - latest: the most recent feature release (e.g. 26)
+        - stable: the most recent LTS release (e.g. 25)
+        - recent_releases: the available LTS releases, newest first
+
+        Args:
+            recent_count: Maximum number of LTS releases to include
+
+        Returns:
+            VersionInfo object containing version information
+        """
+        try:
+            response = self.session.get(self.available_releases_url, timeout=10)
+            response.raise_for_status()
+            data = cast(JsonObject, response.json())
+
+            # LTS releases are the meaningful axis for a Java CI matrix
+            lts_raw = cast(List[object], data.get("available_lts_releases", []))
+            lts_sorted = sorted((int(str(v)) for v in lts_raw), reverse=True)
+
+            most_recent_feature = data.get("most_recent_feature_release")
+            most_recent_lts = data.get("most_recent_lts")
+
+            recent_releases = [
+                ReleaseInfo(version=str(v), prerelease=False)
+                for v in lts_sorted[:recent_count]
+            ]
+
+            latest = (
+                str(most_recent_feature) if most_recent_feature is not None else None
+            )
+            stable = str(most_recent_lts) if most_recent_lts is not None else None
+
+            return VersionInfo(
+                latest=latest,
+                stable=stable,
+                recent_releases=recent_releases,
+                details={
+                    "fetch_time": get_utc_now().isoformat(),
+                    "source": "adoptium:info/available_releases",
+                    "most_recent_feature_release": most_recent_feature,
+                    "most_recent_lts": most_recent_lts,
+                    "available_lts_releases": lts_sorted,
+                },
+            )
+        except Exception as error:
+            self.logger.error("Error fetching versions: %s", str(error), exc_info=True)
+            return VersionInfo(
+                details={"error": str(error), "error_type": type(error).__name__}
+            )
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Fetch Java version information")
+    parser.add_argument(
+        "--count", type=int, default=5, help="Number of versions to fetch"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="count", default=0, help="Increase verbosity"
+    )
+    args = parser.parse_args()
+
+    # Set up logging
+    logger = setup_logging(args.verbose)
+
+    # Display header in verbose mode
+    if args.verbose > 0:
+        print("\n=== Fetching Java Versions (Adoptium API) ===")
+
+    # Main processing
+    fetcher = JavaVersionFetcher()
+    versions = fetcher.fetch_versions(recent_count=args.count)
+
+    # Output results
+    print(
+        json.dumps(
+            {
+                "latest": versions.latest,
+                "stable": versions.stable,
+                "recent_releases": [vars(r) for r in versions.recent_releases],
+                "details": versions.details,
+            },
+            indent=2,
+        )
+    )

--- a/json2vars_setter/version/registry.py
+++ b/json2vars_setter/version/registry.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict
 from json2vars_setter.version.core.base import BaseVersionFetcher
 from json2vars_setter.version.fetchers.dotnet import DotnetVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
+from json2vars_setter.version.fetchers.java import JavaVersionFetcher
 from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
 from json2vars_setter.version.fetchers.php import PhpVersionFetcher
 from json2vars_setter.version.fetchers.python import PythonVersionFetcher
@@ -26,6 +27,7 @@ LANGUAGE_FETCHERS: Dict[str, Callable[[], BaseVersionFetcher]] = {
     "rust": RustVersionFetcher,
     "php": PhpVersionFetcher,
     "dotnet": DotnetVersionFetcher,
+    "java": JavaVersionFetcher,
 }
 
 

--- a/tests/features/test_matrix_update.py
+++ b/tests/features/test_matrix_update.py
@@ -303,6 +303,7 @@ def test_main_function(mocker: MockerFixture) -> None:
             "rust": "stable",
             "php": "stable",
             "dotnet": "stable",
+            "java": "stable",
         },
         False,
     )
@@ -320,6 +321,8 @@ def test_main_function(mocker: MockerFixture) -> None:
             "stable",
             "--dotnet",
             "latest",
+            "--java",
+            "both",
             "--dry-run",
         ],
     )
@@ -327,7 +330,13 @@ def test_main_function(mocker: MockerFixture) -> None:
     main()
     mock_update.assert_called_with(
         os.path.join(".github", "json2vars-setter", "matrix.json"),  # Default path
-        {"python": "latest", "nodejs": "both", "php": "stable", "dotnet": "latest"},
+        {
+            "python": "latest",
+            "nodejs": "both",
+            "php": "stable",
+            "dotnet": "latest",
+            "java": "both",
+        },
         True,  # dry_run=True
     )
 

--- a/tests/version/fetchers/test_java.py
+++ b/tests/version/fetchers/test_java.py
@@ -1,0 +1,110 @@
+import pytest
+import pytest_mock
+
+from json2vars_setter.version.fetchers.java import JavaVersionFetcher
+
+
+@pytest.fixture
+def java_fetcher() -> JavaVersionFetcher:
+    """Fixture to create a JavaVersionFetcher instance"""
+    return JavaVersionFetcher()
+
+
+def test_init(java_fetcher: JavaVersionFetcher) -> None:
+    """Test __init__ sets the Adoptium API endpoint"""
+    assert java_fetcher.github_owner == "adoptium"
+    assert java_fetcher.github_repo == "temurin"
+    assert java_fetcher.available_releases_url == (
+        "https://api.adoptium.net/v3/info/available_releases"
+    )
+
+
+def test_fetch_versions_success(
+    java_fetcher: JavaVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test fetch_versions with a successful Adoptium API response"""
+    mock_response = mocker.Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "available_releases": [8, 11, 16, 17, 21, 22, 23, 24, 25, 26],
+        "available_lts_releases": [8, 11, 17, 21, 25],
+        "most_recent_feature_release": 26,
+        "most_recent_lts": 25,
+        "tip_version": 27,
+    }
+    mocker.patch.object(java_fetcher.session, "get", return_value=mock_response)
+
+    versions = java_fetcher.fetch_versions(recent_count=5)
+
+    assert versions.latest == "26"
+    assert versions.stable == "25"
+
+    # recent_releases are the LTS releases, newest first
+    recent_versions = [r.version for r in versions.recent_releases]
+    assert recent_versions == ["25", "21", "17", "11", "8"]
+
+    # Details
+    assert versions.details["source"] == "adoptium:info/available_releases"
+    assert versions.details["most_recent_feature_release"] == 26
+    assert versions.details["most_recent_lts"] == 25
+    assert versions.details["available_lts_releases"] == [25, 21, 17, 11, 8]
+    assert "fetch_time" in versions.details
+
+
+def test_fetch_versions_respects_recent_count(
+    java_fetcher: JavaVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test fetch_versions limits recent_releases to recent_count"""
+    mock_response = mocker.Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "available_lts_releases": [8, 11, 17, 21, 25],
+        "most_recent_feature_release": 26,
+        "most_recent_lts": 25,
+    }
+    mocker.patch.object(java_fetcher.session, "get", return_value=mock_response)
+
+    versions = java_fetcher.fetch_versions(recent_count=2)
+
+    recent_versions = [r.version for r in versions.recent_releases]
+    assert recent_versions == ["25", "21"]
+
+
+def test_fetch_versions_missing_fields(
+    java_fetcher: JavaVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test fetch_versions handles missing fields gracefully"""
+    mock_response = mocker.Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {}  # no fields at all
+    mocker.patch.object(java_fetcher.session, "get", return_value=mock_response)
+
+    versions = java_fetcher.fetch_versions()
+
+    assert versions.latest is None
+    assert versions.stable is None
+    assert versions.recent_releases == []
+    assert versions.details["available_lts_releases"] == []
+
+
+def test_fetch_versions_error(
+    java_fetcher: JavaVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test fetch_versions returns error details when the API call fails"""
+    mocker.patch.object(java_fetcher, "logger", mocker.Mock())
+    mocker.patch.object(java_fetcher.session, "get", side_effect=Exception("API error"))
+
+    versions = java_fetcher.fetch_versions()
+
+    assert versions.latest is None
+    assert versions.stable is None
+    assert "error" in versions.details
+    assert versions.details["error_type"] == "Exception"
+
+
+def test_abstract_methods_not_used(java_fetcher: JavaVersionFetcher) -> None:
+    """The GitHub-tag hooks are intentionally unused for the Adoptium-based fetcher"""
+    with pytest.raises(NotImplementedError):
+        java_fetcher._is_stable_tag({"name": "irrelevant"})
+    with pytest.raises(NotImplementedError):
+        java_fetcher._parse_version_from_tag({"name": "irrelevant"})

--- a/tests/version/test_registry.py
+++ b/tests/version/test_registry.py
@@ -4,6 +4,7 @@ import pytest
 
 from json2vars_setter.version.fetchers.dotnet import DotnetVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
+from json2vars_setter.version.fetchers.java import JavaVersionFetcher
 from json2vars_setter.version.fetchers.nodejs import NodejsVersionFetcher
 from json2vars_setter.version.fetchers.php import PhpVersionFetcher
 from json2vars_setter.version.fetchers.python import PythonVersionFetcher
@@ -21,6 +22,7 @@ def test_get_version_fetcher_returns_expected_type() -> None:
     assert isinstance(get_version_fetcher("rust"), RustVersionFetcher)
     assert isinstance(get_version_fetcher("php"), PhpVersionFetcher)
     assert isinstance(get_version_fetcher("dotnet"), DotnetVersionFetcher)
+    assert isinstance(get_version_fetcher("java"), JavaVersionFetcher)
 
 
 def test_get_version_fetcher_unsupported_language() -> None:

--- a/zensical.toml
+++ b/zensical.toml
@@ -33,6 +33,7 @@ nav = [
   ]},
   { "Reference" = [
     { "Command Options" = "reference/options.md" },
+    { "Version Sources" = "reference/version-sources.md" },
   ]},
   { "Contributing" = "contributing.md" },
 ]


### PR DESCRIPTION
## Summary

Add **Java** as a supported language (Tier 1). Unlike the other languages, Java versions
are fetched from the **Adoptium API** rather than GitHub tags, because `openjdk/jdk` only
carries early-access builds of the in-development release and GA/LTS lines live in separate
repositories. Includes the full repo structure: fetcher, action contract, tests, example
project, CI workflow, status badge, and docs.

Closes #505

## Why the Adoptium API (not GitHub tags)

| Candidate | Verdict |
|---|---|
| `openjdk/jdk` tags | Rejected — only early-access builds of the in-dev release (e.g. `jdk-28+0`) |
| `openjdk/jdkXXu` update repos | Rejected — many repos, mixes build metadata |
| **Adoptium API** `/v3/info/available_releases` | **Chosen** — one authoritative endpoint with LTS/feature distinction |

`latest` = most recent **feature** release (e.g. 26); `stable` = most recent **LTS**
(e.g. 25). This is the only fetcher that overrides `fetch_versions`.

## Changes

### Core
- **`version/fetchers/java.py`**: `JavaVersionFetcher` (Adoptium API)
- **`version/registry.py`**: register `"java"`
- **`features/matrix_update.py`**: `--java` strategy arg (+ `--all` / `main()` wiring)
- **`action.yml`**: `java-strategy` input, `versions_java` output, strategy arg, summary

### Tests (100% coverage)
- `tests/version/fetchers/test_java.py` (covers `java.py` fully, incl. error path)
- `tests/version/test_registry.py`, `tests/features/test_matrix_update.py` updates

### Example project & CI
- `examples/java/`: Maven + JUnit 5 + Jackson JSON-parser sample (`java_project_matrix.json`,
  README). Targets Java 11 bytecode so it builds/runs on every JDK in the matrix.
- `.github/workflows/java_test.yml`: `set_variables` -> `run_tests` (OS x Java matrix via
  official `actions/setup-java`, temurin) -> `update_badge` (dedicated gist)

### Badges & docs
- `README.md` / `docs/index.md`: Java status badge + supported-languages prose
- **`docs/reference/version-sources.md`**: NEW reference page documenting **every**
  language's version source, candidates considered, rationale, and characteristics
  (added to the docs nav)
- `docs/reference/options.md`, `docs/features/{dynamic-update,index}.md`, `CLAUDE.md`

## Verification

| Check | Result |
|---|---|
| `mypy --config-file=pyproject.toml` | Pass (43 files, strict + no-Any) |
| `ruff check` / `ruff format --check` | Pass |
| `pytest` + coverage | 230 passed, 100% coverage (`java.py` 100%) |

## Release ordering (two-phase action reference)

`java_test.yml` uses `uses: ./` so it tests the PR code and is green now. **Follow-up after
the Java release:** switch it to the pinned tag to match the other `*_test.yml` workflows
(tracked via a `TODO` and CLAUDE.md "Adding a New Language" point 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)