### PR TITLE
:pushpin: Pin java_test.yml to json2vars-setter@v1.6.0

### DIFF
--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Java): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.6.0
         with:
           json-file: examples/java/java_project_matrix.json
 


### PR DESCRIPTION
## Summary

Java support shipped in **v1.6.0**, so the published tag now exposes `versions_java`.
Switch `java_test.yml` from the in-repo `uses: ./` to the pinned release tag
`uses: 7rikazhexde/json2vars-setter@v1.6.0`.

This completes the documented two-phase action reference for a new language
(see CLAUDE.md "Adding a New Language", point 9). From here on `sync-version-refs.sh`
keeps it pinned to the latest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)