### PR TITLE
:sparkles: Add Deno version support

### DIFF
--- a/.github/workflows/deno_test.yml
+++ b/.github/workflows/deno_test.yml
@@ -1,0 +1,158 @@
+name: Deno Test
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'examples/deno/**'
+      - '.github/workflows/deno_test.yml'
+
+jobs:
+  set_variables:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.json2vars.outputs.os }}
+      versions_deno: ${{ steps.json2vars.outputs.versions_deno }}
+      ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set variables from JSON
+        id: json2vars
+        # Use the in-repo action so this workflow tests the current code. A new
+        # language's `versions_<lang>` output does not exist in the published tag
+        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
+        # until then; `./` keeps the example workflow green from the first PR.
+        # TODO(after the release that adds Deno): switch to the pinned tag
+        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
+        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
+        uses: ./
+        with:
+          json-file: examples/deno/deno_project_matrix.json
+
+      - name: Debug output values
+        run: |
+          echo "os: ${{ steps.json2vars.outputs.os }}"
+          echo "os[0]: ${{ fromJson(steps.json2vars.outputs.os)[0] }}"
+          echo "os[1]: ${{ fromJson(steps.json2vars.outputs.os)[1] }}"
+          echo "os[2]: ${{ fromJson(steps.json2vars.outputs.os)[2] }}"
+          echo "versions_deno: ${{ steps.json2vars.outputs.versions_deno }}"
+          echo "versions_deno[0]: ${{ fromJson(steps.json2vars.outputs.versions_deno)[0] }}"
+          echo "versions_deno[1]: ${{ fromJson(steps.json2vars.outputs.versions_deno)[1] }}"
+          echo "ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}"
+
+  run_tests:
+    needs: set_variables
+    strategy:
+      # Run every matrix combination even if one fails so the aggregated job
+      # result reflects the status of the whole matrix (used by the badge).
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.set_variables.outputs.os) }}
+        deno-version: ${{ fromJson(needs.set_variables.outputs.versions_deno) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: ${{ matrix.deno-version }}
+
+      - name: Set timezone
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
+        with:
+          timezoneLinux: "Asia/Tokyo"
+          timezoneMacos: "Asia/Tokyo"
+          timezoneWindows: "Tokyo Standard Time"
+
+      - name: Display Deno version
+        run: deno --version
+
+      - name: Show matrix
+        shell: bash
+        run: |
+          # For non-list case
+          ghpages_branch="${{ needs.set_variables.outputs.ghpages_branch }}"
+
+          # For list case, explicitly enclose the list in "" to make it a string. (Note that it is not ''.)
+          os='${{ needs.set_variables.outputs.os }}'
+          versions_deno='${{ needs.set_variables.outputs.versions_deno }}'
+
+          # For list index case
+          os_0="${{ fromJson(needs.set_variables.outputs.os)[0] }}"
+          os_1="${{ fromJson(needs.set_variables.outputs.os)[1] }}"
+          os_2="${{ fromJson(needs.set_variables.outputs.os)[2] }}"
+
+          versions_deno_0="${{ fromJson(needs.set_variables.outputs.versions_deno)[0] }}"
+          versions_deno_1="${{ fromJson(needs.set_variables.outputs.versions_deno)[1] }}"
+
+          echo "os: ${os}"
+          echo "os_0: ${os_0}"
+          echo "os_1: ${os_1}"
+          echo "os_2: ${os_2}"
+          echo "versions_deno: ${versions_deno}"
+          echo "versions_deno_0: ${versions_deno_0}"
+          echo "versions_deno_1: ${versions_deno_1}"
+          echo "ghpages_branch: ${ghpages_branch}"
+
+          # For loop case
+          os_list=$(echo "${os}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          deno_versions_list=$(echo "${versions_deno}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+
+          for current_os in ${os_list}; do
+            for version in ${deno_versions_list}; do
+              echo "Current OS: ${current_os}, Current Deno Version: ${version}"
+            done
+          done
+
+      - name: Run tests
+        id: deno_test
+        working-directory: ./examples/deno
+        shell: bash
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
+        run: |
+          deno test --allow-read
+
+  update_badge:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Determine status and color
+        id: status
+        shell: bash
+        run: |
+          # needs.run_tests.result aggregates every matrix combination:
+          # 'success' only when all passed, 'failure' if any leg failed.
+          case "${{ needs.run_tests.result }}" in
+            success)   status=passing;   color=2ea44f ;;
+            failure)   status=failing;   color=cf222e ;;
+            cancelled) status=cancelled; color=808080 ;;
+            skipped)   status=skipped;   color=808080 ;;
+            *)         status=pending;   color=dbab09 ;;
+          esac
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
+
+      - name: Create badge
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 5a34d5cdfb2b13ed4ab1939009b6f5b1
+          filename: deno-test-badge.json
+          label: Deno Test
+          message: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          labelColor: "24292f"
+          style: "flat"
+          namedLogo: "github"
+          logoColor: "white"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, PHP, .NET (C#), and Java. The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
+json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, PHP, .NET (C#), Java, and Deno. The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
 
 ## Common Commands
 
@@ -79,7 +79,7 @@ A pluggable architecture for fetching language versions from GitHub:
 - **`version/core/base.py`** — `BaseVersionFetcher` abstract class handles GitHub API pagination, authentication (via `GITHUB_TOKEN`), and defines the interface (`_is_stable_tag()`, `_parse_version_from_tag()`)
 - **`version/core/exceptions.py`** — Exception hierarchy: `VersionFetchError` → `GitHubAPIError`, `ParseError`, `ValidationError`
 - **`version/core/utils.py`** — Shared data classes (`VersionInfo`, `ReleaseInfo`) and helpers
-- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`, `dotnet.py`, `java.py`). Most parse tags from the respective GitHub repository; `java.py` is the exception — it overrides `fetch_versions` to query the Adoptium API (see `docs/reference/version-sources.md`)
+- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`, `dotnet.py`, `java.py`, `deno.py`). Most parse tags from the respective GitHub repository; `java.py` is the exception — it overrides `fetch_versions` to query the Adoptium API (see `docs/reference/version-sources.md`)
 
 ### Entry Points
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), and Java
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, and Deno
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -41,6 +41,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat&logo=php&logoColor=white) | [![setup-php](https://img.shields.io/badge/setup--php-777BB4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-php-action) | [![PHP Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/a9bc428c9f5a2f998bd7307038e557e1/raw/php-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/php_test.yml) |
 | ![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white) | [![setup-dotnet](https://img.shields.io/badge/setup--dotnet-512BD4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-dotnet) | [![.NET Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/33c8a05d3ed6c038877d847ffc12b2f9/raw/dotnet-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/dotnet_test.yml) |
 | ![Java](https://img.shields.io/badge/Java-007396?style=flat&logo=openjdk&logoColor=white) | [![setup-java](https://img.shields.io/badge/setup--java-007396?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-java-jdk) | [![Java Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/813e5201a834d06253014b66ee8fd154/raw/java-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/java_test.yml) |
+| ![Deno](https://img.shields.io/badge/Deno-000000?style=flat&logo=deno&logoColor=white) | [![setup-deno](https://img.shields.io/badge/setup--deno-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-deno) | [![Deno Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5a34d5cdfb2b13ed4ab1939009b6f5b1/raw/deno-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/deno_test.yml) |
 
 ## Quick Start
 

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ inputs:
   java-strategy:
     description: 'Update strategy for Java versions (stable, latest, or both)'
     required: false  # Optional
+  deno-strategy:
+    description: 'Update strategy for Deno versions (stable, latest, or both)'
+    required: false  # Optional
 
   # Safe Mode
   dry-run:
@@ -144,6 +147,9 @@ outputs:
   versions_java:
     description: 'List of Java versions'
     value: ${{ steps.set_outputs.outputs.versions_java }}
+  versions_deno:
+    description: 'List of Deno versions'
+    value: ${{ steps.set_outputs.outputs.versions_deno }}
   ghpages_branch:
     description: 'GitHub Pages branch'
     value: ${{ steps.set_outputs.outputs.ghpages_branch }}
@@ -216,6 +222,9 @@ runs:
           fi
           if [[ -n "${{ inputs.java-strategy }}" ]]; then
             ARGS+=("--java" "${{ inputs.java-strategy }}")
+          fi
+          if [[ -n "${{ inputs.deno-strategy }}" ]]; then
+            ARGS+=("--deno" "${{ inputs.deno-strategy }}")
           fi
         fi
 
@@ -338,4 +347,5 @@ runs:
         echo "PHP Versions: ${{ steps.set_outputs.outputs.versions_php }}"
         echo ".NET Versions: ${{ steps.set_outputs.outputs.versions_dotnet }}"
         echo "Java Versions: ${{ steps.set_outputs.outputs.versions_java }}"
+        echo "Deno Versions: ${{ steps.set_outputs.outputs.versions_deno }}"
         echo "GitHub Pages Branch: ${{ steps.set_outputs.outputs.ghpages_branch }}"

--- a/docs/features/dynamic-update.md
+++ b/docs/features/dynamic-update.md
@@ -195,6 +195,7 @@ The Dynamic Matrix Updater accepts the following inputs:
 | `php-strategy` | Strategy for PHP versions | No | - |
 | `dotnet-strategy` | Strategy for .NET (C#) versions | No | - |
 | `java-strategy` | Strategy for Java versions | No | - |
+| `deno-strategy` | Strategy for Deno versions | No | - |
 | `dry-run` | Run without updating the file | No | `'false'` |
 
 ## How It Works
@@ -248,6 +249,7 @@ The Dynamic Matrix Updater currently supports:
 - **PHP**: Fetches from PHP releases via GitHub API
 - **.NET (C#)**: Fetches from .NET SDK releases via GitHub API
 - **Java**: Fetches from the Adoptium API (latest feature release / latest LTS)
+- **Deno**: Fetches from Deno releases via GitHub API
 
 ## Best Practices
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -109,7 +109,7 @@ graph LR
 - **Automated Version Updates**: Keep testing matrices current without manual intervention
 - **Efficient API Usage**: Reduce external API calls by caching version information
 - **Cross-Platform Testing**: Define operating systems and language versions for comprehensive testing
-- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), and Java in a single configuration
+- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, and Deno in a single configuration
 
 ## Component Integration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), and Java
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, and Deno
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -28,6 +28,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat&logo=php&logoColor=white) | [![setup-php](https://img.shields.io/badge/setup--php-777BB4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-php-action) | [![PHP Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/a9bc428c9f5a2f998bd7307038e557e1/raw/php-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/php_test.yml) |
 | ![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white) | [![setup-dotnet](https://img.shields.io/badge/setup--dotnet-512BD4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-dotnet) | [![.NET Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/33c8a05d3ed6c038877d847ffc12b2f9/raw/dotnet-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/dotnet_test.yml) |
 | ![Java](https://img.shields.io/badge/Java-007396?style=flat&logo=openjdk&logoColor=white) | [![setup-java](https://img.shields.io/badge/setup--java-007396?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-java-jdk) | [![Java Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/813e5201a834d06253014b66ee8fd154/raw/java-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/java_test.yml) |
+| ![Deno](https://img.shields.io/badge/Deno-000000?style=flat&logo=deno&logoColor=white) | [![setup-deno](https://img.shields.io/badge/setup--deno-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-deno) | [![Deno Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5a34d5cdfb2b13ed4ab1939009b6f5b1/raw/deno-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/deno_test.yml) |
 
 ## Quick Start
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -24,6 +24,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `php-strategy` | Update strategy for PHP versions | ✗ | - | Same valid values as `update-strategy` |
 | `dotnet-strategy` | Update strategy for .NET (C#) versions | ✗ | - | Same valid values as `update-strategy` |
 | `java-strategy` | Update strategy for Java versions | ✗ | - | Same valid values as `update-strategy` |
+| `deno-strategy` | Update strategy for Deno versions | ✗ | - | Same valid values as `update-strategy` |
 | `dry-run` | Run in dry-run mode without updating the JSON file | ✗ | `false` | For testing update strategies |
 
 ### Cache Version Options
@@ -56,6 +57,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `versions_php` | List of PHP versions | `["8.2.0", "8.3.0", "8.4.0"]` |
 | `versions_dotnet` | List of .NET (C#) versions | `["8.0.100", "9.0.100"]` |
 | `versions_java` | List of Java versions | `["21", "17", "11"]` |
+| `versions_deno` | List of Deno versions | `["2.1.4", "1.46.3"]` |
 | `ghpages_branch` | GitHub Pages branch name | `"gh-pages"` |
 
 ## Usage Notes

--- a/docs/reference/version-sources.md
+++ b/docs/reference/version-sources.md
@@ -39,6 +39,7 @@ The dynamic-update strategies map onto these fields:
 | PHP | `php/php-src` tags | newest stable | previous minor | `shivammathur/setup-php` |
 | .NET (C#) | `dotnet/sdk` tags | newest SDK | previous **major** | `actions/setup-dotnet` |
 | Java | **Adoptium API** | newest **feature** | newest **LTS** | `actions/setup-java` |
+| Deno | `denoland/deno` tags | newest stable | previous minor | `denoland/setup-deno` |
 
 ## Per-language details
 
@@ -126,6 +127,15 @@ The dynamic-update strategies map onto these fields:
   releases, newest first. The consumer side uses the official `actions/setup-java` with
   the `temurin` distribution; example matrices use major versions (`"11"`, `"17"`,
   `"21"`).
+
+### Deno — `denoland/deno`
+
+- **Source:** tags of the official Deno repository (`vX.Y.Z`).
+- **Why:** Deno publishes clean, stable-only release tags (no pre-release noise), so it is
+  a direct fit for the GitHub-tags fetcher.
+- **Characteristics:** the `v` prefix is stripped; `stable` is the previous minor of
+  `latest`. Example matrices use the channel form (`"v1.x"`, `"v2.x"`) that
+  `denoland/setup-deno` accepts.
 
 ## Adding another language
 

--- a/examples/deno/README.md
+++ b/examples/deno/README.md
@@ -1,0 +1,52 @@
+# Deno Example for json2vars-setter
+
+This is a Deno implementation example for parsing JSON configuration files in
+GitHub Actions matrix testing.
+
+## Requirements
+
+- Deno 1.x or 2.x
+
+## Project Structure
+
+```bash
+.
+├── json_parser.ts            # Main implementation
+├── json_parser_test.ts       # Test implementation
+└── deno_project_matrix.json  # Matrix definition consumed by json2vars-setter
+```
+
+## Setup & Running
+
+Run the parser:
+
+```bash
+cd examples/deno
+deno run --allow-read json_parser.ts
+```
+
+Run the tests:
+
+```bash
+deno test --allow-read
+```
+
+## Matrix file
+
+`deno_project_matrix.json` defines the OS list and Deno versions used by the matrix
+testing workflow. The versions use the form accepted by
+[`denoland/setup-deno`](https://github.com/marketplace/actions/setup-deno)
+(e.g. `v1.x`, `v2.x`, or an exact `2.1.4`):
+
+```json
+{
+    "os": ["ubuntu-latest", "windows-latest", "macos-latest"],
+    "versions": {
+        "deno": ["v1.x", "v2.x"]
+    },
+    "ghpages_branch": "ghgapes"
+}
+```
+
+The `.github/workflows/deno_test.yml` workflow reads this file through json2vars-setter
+and runs the tests across every OS / Deno version combination.

--- a/examples/deno/deno_project_matrix.json
+++ b/examples/deno/deno_project_matrix.json
@@ -1,0 +1,14 @@
+{
+    "os": [
+        "ubuntu-latest",
+        "windows-latest",
+        "macos-latest"
+    ],
+    "versions": {
+        "deno": [
+            "v1.x",
+            "v2.x"
+        ]
+    },
+    "ghpages_branch": "ghgapes"
+}

--- a/examples/deno/json_parser.ts
+++ b/examples/deno/json_parser.ts
@@ -1,0 +1,27 @@
+// Minimal JSON configuration parser used to demonstrate consuming the
+// json2vars-setter matrix file in a Deno project.
+
+export function parseConfig(
+  filePath: string | URL,
+  silent = false,
+): Record<string, unknown> | null {
+  try {
+    const contents = Deno.readTextFileSync(filePath);
+    return JSON.parse(contents) as Record<string, unknown>;
+  } catch (e) {
+    if (!silent) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error(`Error reading or parsing JSON: ${message}`);
+    }
+    return null;
+  }
+}
+
+if (import.meta.main) {
+  const result = parseConfig(
+    new URL("./deno_project_matrix.json", import.meta.url),
+  );
+  if (result !== null) {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}

--- a/examples/deno/json_parser_test.ts
+++ b/examples/deno/json_parser_test.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { parseConfig } from "./json_parser.ts";
+
+const configUrl = new URL("./deno_project_matrix.json", import.meta.url);
+
+Deno.test("parses the JSON file", () => {
+  const result = parseConfig(configUrl);
+  assertEquals(typeof result, "object");
+  assertEquals(result !== null, true);
+});
+
+Deno.test("parses the expected values", () => {
+  const result = parseConfig(configUrl) as Record<string, unknown>;
+
+  const os = result["os"] as string[];
+  assertEquals(os.includes("ubuntu-latest"), true);
+  assertEquals(os.includes("windows-latest"), true);
+  assertEquals(os.includes("macos-latest"), true);
+
+  const versions = result["versions"] as Record<string, string[]>;
+  assertEquals(versions["deno"], ["v1.x", "v2.x"]);
+
+  assertEquals(result["ghpages_branch"], "ghgapes");
+});
+
+Deno.test("returns null for a missing file", () => {
+  const result = parseConfig("non-existent.json", true);
+  assertEquals(result, null);
+});

--- a/json2vars_setter/features/matrix_update.py
+++ b/json2vars_setter/features/matrix_update.py
@@ -280,6 +280,11 @@ Examples:
         help="Strategy for Java versions",
     )
     parser.add_argument(
+        "--deno",
+        choices=["stable", "latest", "both"],
+        help="Strategy for Deno versions",
+    )
+    parser.add_argument(
         "--all",
         choices=["stable", "latest", "both"],
         help="Apply the same strategy to all languages",
@@ -315,6 +320,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         args.php = args.all
         args.dotnet = args.all
         args.java = args.all
+        args.deno = args.all
 
     # Collect language strategies
     language_strategies: Dict[str, str] = {}
@@ -334,6 +340,8 @@ def main(argv: Optional[List[str]] = None) -> None:
         language_strategies["dotnet"] = args.dotnet
     if args.java:
         language_strategies["java"] = args.java
+    if args.deno:
+        language_strategies["deno"] = args.deno
 
     if not language_strategies:
         parser.error("At least one language strategy must be specified")

--- a/json2vars_setter/version/fetchers/deno.py
+++ b/json2vars_setter/version/fetchers/deno.py
@@ -1,0 +1,193 @@
+import os
+import re
+from typing import List, Tuple, cast
+
+import requests
+
+from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.core.exceptions import ParseError
+from json2vars_setter.version.core.utils import (
+    JsonObject,
+    ReleaseInfo,
+    check_github_api,
+    setup_logging,
+)
+
+# Stable Deno tags look exactly like "v2.1.4"; the repository does not publish
+# pre-release tags, so any tag matching this pattern is a stable release.
+_STABLE_TAG_PATTERN = re.compile(r"v\d+\.\d+\.\d+$")
+
+
+class DenoVersionFetcher(BaseVersionFetcher):
+    """Fetches Deno version information from GitHub"""
+
+    def __init__(self) -> None:
+        """Initialize with Deno's GitHub repository information"""
+        super().__init__("denoland", "deno")
+
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
+        """
+        Check if a tag represents a stable Deno release
+
+        Args:
+            tag: Tag information from GitHub API
+
+        Returns:
+            True if the tag represents a stable release, False otherwise
+        """
+        name = str(tag.get("name", ""))
+
+        # Deno uses format "vX.Y.Z" for stable releases
+        return bool(_STABLE_TAG_PATTERN.fullmatch(name))
+
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
+        """
+        Parse version information from a Deno tag
+
+        Args:
+            tag: Tag information from GitHub API
+
+        Returns:
+            Parsed ReleaseInfo object
+
+        Raises:
+            ParseError: If required version information cannot be parsed
+        """
+        name = str(tag.get("name", ""))
+        if not name:
+            raise ParseError("No tag name found")
+
+        # Clean version string (e.g., "v2.1.4" -> "2.1.4")
+        version = name.removeprefix("v")
+
+        # All filtered tags are considered stable
+        prerelease = False
+
+        return ReleaseInfo(
+            version=version,
+            release_date=None,
+            prerelease=prerelease,
+            additional_info={
+                "tag_name": name,
+                "commit": {"sha": cast(JsonObject, tag.get("commit", {})).get("sha")},
+                "tarball_url": tag.get("tarball_url"),
+                "zipball_url": tag.get("zipball_url"),
+            },
+        )
+
+    def _get_stability_criteria(
+        self, releases: List[ReleaseInfo]
+    ) -> Tuple[ReleaseInfo, ReleaseInfo]:
+        """
+        Determine the stable and latest versions of Deno
+
+        - latest: the most recent release version
+        - stable: usually the previous minor version of latest
+
+        Args:
+            releases: List of release information
+
+        Returns:
+            Tuple of (latest_release, stable_release)
+        """
+        if not releases:
+            # Raise an exception to explicitly handle the case where no releases are available
+            raise ValueError("No releases available")
+
+        # The latest version is always the first release
+        latest = releases[0]
+
+        # Get and parse the version number
+        latest_version = latest.version
+        match = re.match(r"(\d+)\.(\d+)\.(\d+)", latest_version)
+
+        if match:
+            major, minor, _patch = map(int, match.groups())
+            # Look for the previous minor version
+            prev_minor = minor - 1
+
+            # Search for a release with the previous minor version
+            for release in releases:
+                r_match = re.match(r"(\d+)\.(\d+)\.(\d+)", release.version)
+                if r_match:
+                    r_major, r_minor, _r_patch = map(int, r_match.groups())
+                    if r_major == major and r_minor == prev_minor:
+                        self.logger.info(
+                            f"Using {release.version} as stable vs latest {latest_version}"
+                        )
+                        return latest, release
+
+        # Use the latest version if no suitable stable version is found
+        self.logger.info(
+            f"No suitable stable version found, using latest {latest_version} as stable"
+        )
+        return latest, latest
+
+
+def deno_filter_func(tag: JsonObject) -> bool:
+    """Filter function for Deno tags in API checker"""
+    name = str(tag.get("name", ""))
+    return bool(_STABLE_TAG_PATTERN.fullmatch(name))
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Fetch Deno version information")
+    parser.add_argument(
+        "--count", type=int, default=5, help="Number of versions to fetch"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="count", default=0, help="Increase verbosity"
+    )
+    args = parser.parse_args()
+
+    # Set up logging
+    logger = setup_logging(args.verbose)
+
+    # Check API directly if in verbose mode
+    if args.verbose > 0:
+        # Create a session for API checking
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "json2vars-setter",
+            }
+        )
+
+        # Add GitHub token if available
+        github_token = os.environ.get("GITHUB_TOKEN")
+        if github_token:
+            session.headers.update({"Authorization": f"token {github_token}"})
+
+        check_github_api(
+            session=session,
+            github_owner="denoland",
+            github_repo="deno",
+            count=args.count,
+            filter_func=deno_filter_func,
+        )
+
+    # Display header in verbose mode
+    if args.verbose > 0:
+        print("\n=== Fetching Deno Versions ===")
+
+    # Main processing
+    fetcher = DenoVersionFetcher()
+    versions = fetcher.fetch_versions(recent_count=args.count)
+
+    # Output results
+    print(
+        json.dumps(
+            {
+                "latest": versions.latest,
+                "stable": versions.stable,
+                "recent_releases": [vars(r) for r in versions.recent_releases],
+                "details": versions.details,
+            },
+            indent=2,
+        )
+    )

--- a/json2vars_setter/version/registry.py
+++ b/json2vars_setter/version/registry.py
@@ -8,6 +8,7 @@ shared by the matrix-update and version-cache features.
 from typing import Callable, Dict
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.fetchers.deno import DenoVersionFetcher
 from json2vars_setter.version.fetchers.dotnet import DotnetVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
 from json2vars_setter.version.fetchers.java import JavaVersionFetcher
@@ -28,6 +29,7 @@ LANGUAGE_FETCHERS: Dict[str, Callable[[], BaseVersionFetcher]] = {
     "php": PhpVersionFetcher,
     "dotnet": DotnetVersionFetcher,
     "java": JavaVersionFetcher,
+    "deno": DenoVersionFetcher,
 }
 
 

--- a/tests/features/test_matrix_update.py
+++ b/tests/features/test_matrix_update.py
@@ -304,6 +304,7 @@ def test_main_function(mocker: MockerFixture) -> None:
             "php": "stable",
             "dotnet": "stable",
             "java": "stable",
+            "deno": "stable",
         },
         False,
     )
@@ -323,6 +324,8 @@ def test_main_function(mocker: MockerFixture) -> None:
             "latest",
             "--java",
             "both",
+            "--deno",
+            "latest",
             "--dry-run",
         ],
     )
@@ -336,6 +339,7 @@ def test_main_function(mocker: MockerFixture) -> None:
             "php": "stable",
             "dotnet": "latest",
             "java": "both",
+            "deno": "latest",
         },
         True,  # dry_run=True
     )

--- a/tests/version/fetchers/test_deno.py
+++ b/tests/version/fetchers/test_deno.py
@@ -1,0 +1,180 @@
+from typing import List, cast
+
+import pytest
+import pytest_mock
+
+from json2vars_setter.version.core.exceptions import ParseError
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
+from json2vars_setter.version.fetchers.deno import DenoVersionFetcher, deno_filter_func
+
+
+@pytest.fixture
+def deno_fetcher() -> DenoVersionFetcher:
+    """Fixture to create a DenoVersionFetcher instance"""
+    return DenoVersionFetcher()
+
+
+def test_init(deno_fetcher: DenoVersionFetcher) -> None:
+    """Test __init__ sets the correct GitHub repository information"""
+    assert deno_fetcher.github_owner == "denoland"
+    assert deno_fetcher.github_repo == "deno"
+
+
+def test_is_stable_tag(deno_fetcher: DenoVersionFetcher) -> None:
+    """Test _is_stable_tag method with various tag scenarios"""
+    stable_tags: List[JsonObject] = [
+        {"name": "v2.8.2"},
+        {"name": "v1.46.3"},
+        {"name": "v2.0.0"},
+    ]
+
+    unstable_tags: List[JsonObject] = [
+        {"name": "v2.8.0-rc.1"},
+        {"name": "v2.8"},  # only two components
+        {"name": "2.8.2"},  # missing v prefix
+        {"name": "canary"},
+        {"name": ""},
+    ]
+
+    for tag in stable_tags:
+        assert deno_fetcher._is_stable_tag(tag) is True
+    for tag in unstable_tags:
+        assert deno_fetcher._is_stable_tag(tag) is False
+
+
+def test_parse_version_from_tag(deno_fetcher: DenoVersionFetcher) -> None:
+    """Test _parse_version_from_tag method"""
+    valid_tag: JsonObject = {
+        "name": "v2.1.4",
+        "commit": {"sha": "abc123"},
+        "tarball_url": "https://example.com/tarball",
+        "zipball_url": "https://example.com/zipball",
+    }
+
+    release_info: ReleaseInfo = deno_fetcher._parse_version_from_tag(valid_tag)
+
+    assert release_info.version == "2.1.4"
+    assert release_info.prerelease is False
+    assert release_info.additional_info["tag_name"] == "v2.1.4"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
+    assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
+    assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
+
+    with pytest.raises(ParseError):
+        deno_fetcher._parse_version_from_tag({"name": ""})
+
+
+def test_get_stability_criteria(deno_fetcher: DenoVersionFetcher) -> None:
+    """Test _get_stability_criteria method"""
+    releases: List[ReleaseInfo] = [
+        ReleaseInfo(version="2.8.2"),
+        ReleaseInfo(version="2.7.5"),
+        ReleaseInfo(version="2.6.1"),
+    ]
+
+    latest, stable = deno_fetcher._get_stability_criteria(releases)
+    assert latest.version == "2.8.2"
+    assert stable.version == "2.7.5"
+
+    single_release: List[ReleaseInfo] = [ReleaseInfo(version="2.8.2")]
+    latest, stable = deno_fetcher._get_stability_criteria(single_release)
+    assert latest.version == "2.8.2"
+    assert stable.version == "2.8.2"
+
+    with pytest.raises(ValueError):
+        deno_fetcher._get_stability_criteria([])
+
+
+def test_deno_filter_func() -> None:
+    """Test deno_filter_func with various tag names"""
+    stable_tags: List[JsonObject] = [
+        {"name": "v2.8.2"},
+        {"name": "v1.46.3"},
+    ]
+    unstable_tags: List[JsonObject] = [
+        {"name": "v2.8.0-rc.1"},
+        {"name": "v2.8"},
+        {"name": "latest"},
+        {"name": ""},
+    ]
+    for tag in stable_tags:
+        assert deno_filter_func(tag) is True
+    for tag in unstable_tags:
+        assert deno_filter_func(tag) is False
+
+
+def test_fetch_versions_integration(
+    deno_fetcher: DenoVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test fetch_versions method with mocked API calls"""
+    mock_tags: List[JsonObject] = [
+        {
+            "name": "v2.8.2",
+            "commit": {"sha": "abc123"},
+            "tarball_url": "https://example.com/tarball/2.8.2",
+            "zipball_url": "https://example.com/zipball/2.8.2",
+        },
+        {
+            "name": "v2.7.5",
+            "commit": {"sha": "def456"},
+            "tarball_url": "https://example.com/tarball/2.7.5",
+            "zipball_url": "https://example.com/zipball/2.7.5",
+        },
+    ]
+
+    mocker.patch.object(deno_fetcher, "_get_github_tags", return_value=mock_tags)
+
+    versions = deno_fetcher.fetch_versions(recent_count=2)
+
+    assert versions.latest == "2.8.2"
+    assert versions.stable == "2.7.5"
+    assert len(versions.recent_releases) == 2
+    assert "fetch_time" in versions.details
+    assert versions.details["source"] == "github:denoland/deno"
+
+
+def test_get_stability_criteria_invalid_latest_version(
+    deno_fetcher: DenoVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria when the latest version is unparsable"""
+    mocker.patch.object(deno_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="invalid"),
+        ReleaseInfo(version="2.7.5"),
+    ]
+    latest, stable = deno_fetcher._get_stability_criteria(releases)
+    assert latest.version == "invalid"
+    assert stable.version == "invalid"
+
+
+def test_get_stability_criteria_no_previous_minor(
+    deno_fetcher: DenoVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria when no previous minor version exists"""
+    mocker.patch.object(deno_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="2.8.2"),
+        ReleaseInfo(version="2.8.1"),  # same minor
+        ReleaseInfo(version="1.46.3"),  # different major
+    ]
+    latest, stable = deno_fetcher._get_stability_criteria(releases)
+    assert latest.version == "2.8.2"
+    assert stable.version == "2.8.2"
+
+
+def test_get_stability_criteria_invalid_release_version(
+    deno_fetcher: DenoVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria with an invalid version in the releases list"""
+    mocker.patch.object(deno_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="2.8.2"),
+        ReleaseInfo(version="2.7.invalid"),  # skipped
+        ReleaseInfo(version="2.7.5"),
+    ]
+    latest, stable = deno_fetcher._get_stability_criteria(releases)
+    assert latest.version == "2.8.2"
+    assert stable.version == "2.7.5"

--- a/tests/version/test_registry.py
+++ b/tests/version/test_registry.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from json2vars_setter.version.fetchers.deno import DenoVersionFetcher
 from json2vars_setter.version.fetchers.dotnet import DotnetVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
 from json2vars_setter.version.fetchers.java import JavaVersionFetcher
@@ -23,6 +24,7 @@ def test_get_version_fetcher_returns_expected_type() -> None:
     assert isinstance(get_version_fetcher("php"), PhpVersionFetcher)
     assert isinstance(get_version_fetcher("dotnet"), DotnetVersionFetcher)
     assert isinstance(get_version_fetcher("java"), JavaVersionFetcher)
+    assert isinstance(get_version_fetcher("deno"), DenoVersionFetcher)
 
 
 def test_get_version_fetcher_unsupported_language() -> None:


### PR DESCRIPTION
## Summary

Add **Deno** as a supported language. Versions are fetched from the `denoland/deno`
tags (clean stable-only `vX.Y.Z` tags). Includes the full repo structure: fetcher,
action contract, tests, example project, CI workflow, status badge, and docs.

Closes #513

## Changes

- **`version/fetchers/deno.py`**: `DenoVersionFetcher` + `deno_filter_func`
  (`vX.Y.Z`, `stable` = previous minor)
- **`version/registry.py`**: register `"deno"`
- **`features/matrix_update.py`**: `--deno` strategy arg (+ `--all` / `main()` wiring)
- **`action.yml`**: `deno-strategy` input, `versions_deno` output, strategy arg, summary
- **Tests**: `tests/version/fetchers/test_deno.py` + registry / matrix_update updates
- **Example & CI**: `examples/deno/` (Deno test JSON-parser) +
  `.github/workflows/deno_test.yml` (official `denoland/setup-deno`)
- **Badges & docs**: README / docs/index badge, `docs/reference/{options,version-sources}.md`,
  `docs/features/{dynamic-update,index}.md`, `CLAUDE.md`

## Verification

| Check | Result |
|---|---|
| `mypy --config-file=pyproject.toml` | Pass (45 files, strict + no-Any) |
| `ruff check` / `ruff format --check` | Pass |
| `pytest` + coverage | 239 passed, 100% coverage (`deno.py` 100%) |

## Release ordering

`deno_test.yml` uses `uses: ./` (green now); switch to the pinned tag after the Deno
release (tracked via TODO + CLAUDE.md "Adding a New Language").

🤖 Generated with [Claude Code](https://claude.com/claude-code)