### PR TITLE
:sparkles: Add Bun version support

### DIFF
--- a/.github/workflows/bun_test.yml
+++ b/.github/workflows/bun_test.yml
@@ -1,0 +1,158 @@
+name: Bun Test
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'examples/bun/**'
+      - '.github/workflows/bun_test.yml'
+
+jobs:
+  set_variables:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.json2vars.outputs.os }}
+      versions_bun: ${{ steps.json2vars.outputs.versions_bun }}
+      ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set variables from JSON
+        id: json2vars
+        # Use the in-repo action so this workflow tests the current code. A new
+        # language's `versions_<lang>` output does not exist in the published tag
+        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
+        # until then; `./` keeps the example workflow green from the first PR.
+        # TODO(after the release that adds Bun): switch to the pinned tag
+        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
+        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
+        uses: ./
+        with:
+          json-file: examples/bun/bun_project_matrix.json
+
+      - name: Debug output values
+        run: |
+          echo "os: ${{ steps.json2vars.outputs.os }}"
+          echo "os[0]: ${{ fromJson(steps.json2vars.outputs.os)[0] }}"
+          echo "os[1]: ${{ fromJson(steps.json2vars.outputs.os)[1] }}"
+          echo "os[2]: ${{ fromJson(steps.json2vars.outputs.os)[2] }}"
+          echo "versions_bun: ${{ steps.json2vars.outputs.versions_bun }}"
+          echo "versions_bun[0]: ${{ fromJson(steps.json2vars.outputs.versions_bun)[0] }}"
+          echo "versions_bun[1]: ${{ fromJson(steps.json2vars.outputs.versions_bun)[1] }}"
+          echo "ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}"
+
+  run_tests:
+    needs: set_variables
+    strategy:
+      # Run every matrix combination even if one fails so the aggregated job
+      # result reflects the status of the whole matrix (used by the badge).
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.set_variables.outputs.os) }}
+        bun-version: ${{ fromJson(needs.set_variables.outputs.versions_bun) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Set timezone
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
+        with:
+          timezoneLinux: "Asia/Tokyo"
+          timezoneMacos: "Asia/Tokyo"
+          timezoneWindows: "Tokyo Standard Time"
+
+      - name: Display Bun version
+        run: bun --version
+
+      - name: Show matrix
+        shell: bash
+        run: |
+          # For non-list case
+          ghpages_branch="${{ needs.set_variables.outputs.ghpages_branch }}"
+
+          # For list case, explicitly enclose the list in "" to make it a string. (Note that it is not ''.)
+          os='${{ needs.set_variables.outputs.os }}'
+          versions_bun='${{ needs.set_variables.outputs.versions_bun }}'
+
+          # For list index case
+          os_0="${{ fromJson(needs.set_variables.outputs.os)[0] }}"
+          os_1="${{ fromJson(needs.set_variables.outputs.os)[1] }}"
+          os_2="${{ fromJson(needs.set_variables.outputs.os)[2] }}"
+
+          versions_bun_0="${{ fromJson(needs.set_variables.outputs.versions_bun)[0] }}"
+          versions_bun_1="${{ fromJson(needs.set_variables.outputs.versions_bun)[1] }}"
+
+          echo "os: ${os}"
+          echo "os_0: ${os_0}"
+          echo "os_1: ${os_1}"
+          echo "os_2: ${os_2}"
+          echo "versions_bun: ${versions_bun}"
+          echo "versions_bun_0: ${versions_bun_0}"
+          echo "versions_bun_1: ${versions_bun_1}"
+          echo "ghpages_branch: ${ghpages_branch}"
+
+          # For loop case
+          os_list=$(echo "${os}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          bun_versions_list=$(echo "${versions_bun}" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+
+          for current_os in ${os_list}; do
+            for version in ${bun_versions_list}; do
+              echo "Current OS: ${current_os}, Current Bun Version: ${version}"
+            done
+          done
+
+      - name: Run tests
+        id: bun_test
+        working-directory: ./examples/bun
+        shell: bash
+        # Run directly (no output capture) so test output streams to the log
+        # in real time; the non-zero exit still fails this matrix leg.
+        run: |
+          bun test
+
+  update_badge:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Determine status and color
+        id: status
+        shell: bash
+        run: |
+          # needs.run_tests.result aggregates every matrix combination:
+          # 'success' only when all passed, 'failure' if any leg failed.
+          case "${{ needs.run_tests.result }}" in
+            success)   status=passing;   color=2ea44f ;;
+            failure)   status=failing;   color=cf222e ;;
+            cancelled) status=cancelled; color=808080 ;;
+            skipped)   status=skipped;   color=808080 ;;
+            *)         status=pending;   color=dbab09 ;;
+          esac
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
+
+      - name: Create badge
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 431a19225ef80b473e7eee8e060b7516
+          filename: bun-test-badge.json
+          label: Bun Test
+          message: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          labelColor: "24292f"
+          style: "flat"
+          namedLogo: "github"
+          logoColor: "white"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, PHP, .NET (C#), Java, and Deno. The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
+json2vars-setter is a **GitHub Action** (composite action) that parses JSON files and sets their values as GitHub Actions output variables. It supports dynamic version management and caching for Python, Node.js, Ruby, Go, Rust, PHP, .NET (C#), Java, Deno, and Bun. The action reads a matrix JSON file (default: `.github/json2vars-setter/matrix.json`) and exposes OS lists, language versions, and other config as workflow outputs.
 
 ## Common Commands
 
@@ -79,7 +79,7 @@ A pluggable architecture for fetching language versions from GitHub:
 - **`version/core/base.py`** — `BaseVersionFetcher` abstract class handles GitHub API pagination, authentication (via `GITHUB_TOKEN`), and defines the interface (`_is_stable_tag()`, `_parse_version_from_tag()`)
 - **`version/core/exceptions.py`** — Exception hierarchy: `VersionFetchError` → `GitHubAPIError`, `ParseError`, `ValidationError`
 - **`version/core/utils.py`** — Shared data classes (`VersionInfo`, `ReleaseInfo`) and helpers
-- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`, `dotnet.py`, `java.py`, `deno.py`). Most parse tags from the respective GitHub repository; `java.py` is the exception — it overrides `fetch_versions` to query the Adoptium API (see `docs/reference/version-sources.md`)
+- **`version/fetchers/`** — Language-specific implementations (`python.py`, `nodejs.py`, `ruby.py`, `go.py`, `rust.py`, `php.py`, `dotnet.py`, `java.py`, `deno.py`, `bun.py`). Most parse tags from the respective GitHub repository; `java.py` is the exception — it overrides `fetch_versions` to query the Adoptium API (see `docs/reference/version-sources.md`)
 
 ### Entry Points
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, and Deno
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, Deno, and Bun
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -42,6 +42,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white) | [![setup-dotnet](https://img.shields.io/badge/setup--dotnet-512BD4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-dotnet) | [![.NET Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/33c8a05d3ed6c038877d847ffc12b2f9/raw/dotnet-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/dotnet_test.yml) |
 | ![Java](https://img.shields.io/badge/Java-007396?style=flat&logo=openjdk&logoColor=white) | [![setup-java](https://img.shields.io/badge/setup--java-007396?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-java-jdk) | [![Java Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/813e5201a834d06253014b66ee8fd154/raw/java-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/java_test.yml) |
 | ![Deno](https://img.shields.io/badge/Deno-000000?style=flat&logo=deno&logoColor=white) | [![setup-deno](https://img.shields.io/badge/setup--deno-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-deno) | [![Deno Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5a34d5cdfb2b13ed4ab1939009b6f5b1/raw/deno-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/deno_test.yml) |
+| ![Bun](https://img.shields.io/badge/Bun-000000?style=flat&logo=bun&logoColor=white) | [![setup-bun](https://img.shields.io/badge/setup--bun-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-bun) | [![Bun Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/431a19225ef80b473e7eee8e060b7516/raw/bun-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/bun_test.yml) |
 
 ## Quick Start
 

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,9 @@ inputs:
   deno-strategy:
     description: 'Update strategy for Deno versions (stable, latest, or both)'
     required: false  # Optional
+  bun-strategy:
+    description: 'Update strategy for Bun versions (stable, latest, or both)'
+    required: false  # Optional
 
   # Safe Mode
   dry-run:
@@ -150,6 +153,9 @@ outputs:
   versions_deno:
     description: 'List of Deno versions'
     value: ${{ steps.set_outputs.outputs.versions_deno }}
+  versions_bun:
+    description: 'List of Bun versions'
+    value: ${{ steps.set_outputs.outputs.versions_bun }}
   ghpages_branch:
     description: 'GitHub Pages branch'
     value: ${{ steps.set_outputs.outputs.ghpages_branch }}
@@ -225,6 +231,9 @@ runs:
           fi
           if [[ -n "${{ inputs.deno-strategy }}" ]]; then
             ARGS+=("--deno" "${{ inputs.deno-strategy }}")
+          fi
+          if [[ -n "${{ inputs.bun-strategy }}" ]]; then
+            ARGS+=("--bun" "${{ inputs.bun-strategy }}")
           fi
         fi
 
@@ -348,4 +357,5 @@ runs:
         echo ".NET Versions: ${{ steps.set_outputs.outputs.versions_dotnet }}"
         echo "Java Versions: ${{ steps.set_outputs.outputs.versions_java }}"
         echo "Deno Versions: ${{ steps.set_outputs.outputs.versions_deno }}"
+        echo "Bun Versions: ${{ steps.set_outputs.outputs.versions_bun }}"
         echo "GitHub Pages Branch: ${{ steps.set_outputs.outputs.ghpages_branch }}"

--- a/docs/features/dynamic-update.md
+++ b/docs/features/dynamic-update.md
@@ -196,6 +196,7 @@ The Dynamic Matrix Updater accepts the following inputs:
 | `dotnet-strategy` | Strategy for .NET (C#) versions | No | - |
 | `java-strategy` | Strategy for Java versions | No | - |
 | `deno-strategy` | Strategy for Deno versions | No | - |
+| `bun-strategy` | Strategy for Bun versions | No | - |
 | `dry-run` | Run without updating the file | No | `'false'` |
 
 ## How It Works
@@ -250,6 +251,7 @@ The Dynamic Matrix Updater currently supports:
 - **.NET (C#)**: Fetches from .NET SDK releases via GitHub API
 - **Java**: Fetches from the Adoptium API (latest feature release / latest LTS)
 - **Deno**: Fetches from Deno releases via GitHub API
+- **Bun**: Fetches from Bun releases via GitHub API
 
 ## Best Practices
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -109,7 +109,7 @@ graph LR
 - **Automated Version Updates**: Keep testing matrices current without manual intervention
 - **Efficient API Usage**: Reduce external API calls by caching version information
 - **Cross-Platform Testing**: Define operating systems and language versions for comprehensive testing
-- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, and Deno in a single configuration
+- **Multi-Language Projects**: Support for Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, Deno, and Bun in a single configuration
 
 ## Component Integration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 - **JSON Parsing**: Convert JSON files into GitHub Actions output variables for use in your workflows
 - **Dynamic Version Management**: Automatically update your testing matrix with latest language versions from official sources
 - **Version Caching**: Cache version information to reduce API calls and improve workflow performance
-- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, and Deno
+- **Support for Multiple Languages**: Compatible with Python, Ruby, Node.js, Go, Rust, PHP, .NET (C#), Java, Deno, and Bun
 - **Flexible Configuration**: Maintain a single source of truth for your matrix testing environments
 
 ## Supported Matrix Components
@@ -29,6 +29,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white) | [![setup-dotnet](https://img.shields.io/badge/setup--dotnet-512BD4?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-dotnet) | [![.NET Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/33c8a05d3ed6c038877d847ffc12b2f9/raw/dotnet-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/dotnet_test.yml) |
 | ![Java](https://img.shields.io/badge/Java-007396?style=flat&logo=openjdk&logoColor=white) | [![setup-java](https://img.shields.io/badge/setup--java-007396?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-java-jdk) | [![Java Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/813e5201a834d06253014b66ee8fd154/raw/java-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/java_test.yml) |
 | ![Deno](https://img.shields.io/badge/Deno-000000?style=flat&logo=deno&logoColor=white) | [![setup-deno](https://img.shields.io/badge/setup--deno-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-deno) | [![Deno Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/5a34d5cdfb2b13ed4ab1939009b6f5b1/raw/deno-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/deno_test.yml) |
+| ![Bun](https://img.shields.io/badge/Bun-000000?style=flat&logo=bun&logoColor=white) | [![setup-bun](https://img.shields.io/badge/setup--bun-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-bun) | [![Bun Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/431a19225ef80b473e7eee8e060b7516/raw/bun-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/bun_test.yml) |
 
 ## Quick Start
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -25,6 +25,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `dotnet-strategy` | Update strategy for .NET (C#) versions | ✗ | - | Same valid values as `update-strategy` |
 | `java-strategy` | Update strategy for Java versions | ✗ | - | Same valid values as `update-strategy` |
 | `deno-strategy` | Update strategy for Deno versions | ✗ | - | Same valid values as `update-strategy` |
+| `bun-strategy` | Update strategy for Bun versions | ✗ | - | Same valid values as `update-strategy` |
 | `dry-run` | Run in dry-run mode without updating the JSON file | ✗ | `false` | For testing update strategies |
 
 ### Cache Version Options
@@ -58,6 +59,7 @@ This page provides a comprehensive reference for all configuration options avail
 | `versions_dotnet` | List of .NET (C#) versions | `["8.0.100", "9.0.100"]` |
 | `versions_java` | List of Java versions | `["21", "17", "11"]` |
 | `versions_deno` | List of Deno versions | `["2.1.4", "1.46.3"]` |
+| `versions_bun` | List of Bun versions | `["1.3.14", "1.2.23"]` |
 | `ghpages_branch` | GitHub Pages branch name | `"gh-pages"` |
 
 ## Usage Notes

--- a/docs/reference/version-sources.md
+++ b/docs/reference/version-sources.md
@@ -40,6 +40,7 @@ The dynamic-update strategies map onto these fields:
 | .NET (C#) | `dotnet/sdk` tags | newest SDK | previous **major** | `actions/setup-dotnet` |
 | Java | **Adoptium API** | newest **feature** | newest **LTS** | `actions/setup-java` |
 | Deno | `denoland/deno` tags | newest stable | previous minor | `denoland/setup-deno` |
+| Bun | `oven-sh/bun` tags | newest stable | previous minor | `oven-sh/setup-bun` |
 
 ## Per-language details
 
@@ -136,6 +137,15 @@ The dynamic-update strategies map onto these fields:
 - **Characteristics:** the `v` prefix is stripped; `stable` is the previous minor of
   `latest`. Example matrices use the channel form (`"v1.x"`, `"v2.x"`) that
   `denoland/setup-deno` accepts.
+
+### Bun — `oven-sh/bun`
+
+- **Source:** tags of the official Bun repository (`bun-vX.Y.Z`).
+- **Why:** Bun's release tags are a clean, direct fit for the GitHub-tags fetcher.
+- **Characteristics:** only tags matching `bun-vX.Y.Z` are kept (`canary` and the legacy
+  `v0.x` tags are excluded); the `bun-v` prefix is stripped; `stable` is the previous
+  minor of `latest`. Example matrices use the form (`"1.2.x"`, `"1.3.x"`) that
+  `oven-sh/setup-bun` accepts.
 
 ## Adding another language
 

--- a/examples/bun/README.md
+++ b/examples/bun/README.md
@@ -1,0 +1,52 @@
+# Bun Example for json2vars-setter
+
+This is a Bun implementation example for parsing JSON configuration files in
+GitHub Actions matrix testing.
+
+## Requirements
+
+- Bun 1.x
+
+## Project Structure
+
+```bash
+.
+├── json_parser.ts            # Main implementation
+├── json_parser.test.ts       # Test implementation (bun:test)
+└── bun_project_matrix.json   # Matrix definition consumed by json2vars-setter
+```
+
+## Setup & Running
+
+Run the parser:
+
+```bash
+cd examples/bun
+bun run json_parser.ts
+```
+
+Run the tests:
+
+```bash
+bun test
+```
+
+## Matrix file
+
+`bun_project_matrix.json` defines the OS list and Bun versions used by the matrix
+testing workflow. The versions use the form accepted by
+[`oven-sh/setup-bun`](https://github.com/marketplace/actions/setup-bun)
+(e.g. `1.2.x`, `1.3.x`, `latest`, or an exact `1.3.14`):
+
+```json
+{
+    "os": ["ubuntu-latest", "windows-latest", "macos-latest"],
+    "versions": {
+        "bun": ["1.2.x", "1.3.x"]
+    },
+    "ghpages_branch": "ghgapes"
+}
+```
+
+The `.github/workflows/bun_test.yml` workflow reads this file through json2vars-setter
+and runs the tests across every OS / Bun version combination.

--- a/examples/bun/bun_project_matrix.json
+++ b/examples/bun/bun_project_matrix.json
@@ -1,0 +1,14 @@
+{
+    "os": [
+        "ubuntu-latest",
+        "windows-latest",
+        "macos-latest"
+    ],
+    "versions": {
+        "bun": [
+            "1.2.x",
+            "1.3.x"
+        ]
+    },
+    "ghpages_branch": "ghgapes"
+}

--- a/examples/bun/json_parser.test.ts
+++ b/examples/bun/json_parser.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { parseConfig } from "./json_parser.ts";
+
+const configPath = fileURLToPath(
+  new URL("./bun_project_matrix.json", import.meta.url),
+);
+
+describe("parseConfig", () => {
+  test("parses the JSON file", () => {
+    const result = parseConfig(configPath);
+    expect(result).not.toBeNull();
+  });
+
+  test("parses the expected values", () => {
+    const result = parseConfig(configPath) as Record<string, unknown>;
+
+    const os = result["os"] as string[];
+    expect(os).toContain("ubuntu-latest");
+    expect(os).toContain("windows-latest");
+    expect(os).toContain("macos-latest");
+
+    const versions = result["versions"] as Record<string, string[]>;
+    expect(versions["bun"]).toEqual(["1.2.x", "1.3.x"]);
+
+    expect(result["ghpages_branch"]).toBe("ghgapes");
+  });
+
+  test("returns null for a missing file", () => {
+    const result = parseConfig("non-existent.json", true);
+    expect(result).toBeNull();
+  });
+});

--- a/examples/bun/json_parser.ts
+++ b/examples/bun/json_parser.ts
@@ -1,0 +1,31 @@
+// Minimal JSON configuration parser used to demonstrate consuming the
+// json2vars-setter matrix file in a Bun project.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export function parseConfig(
+  filePath: string,
+  silent = false,
+): Record<string, unknown> | null {
+  try {
+    const contents = readFileSync(filePath, "utf-8");
+    return JSON.parse(contents) as Record<string, unknown>;
+  } catch (e) {
+    if (!silent) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error(`Error reading or parsing JSON: ${message}`);
+    }
+    return null;
+  }
+}
+
+if (import.meta.main) {
+  const configPath = fileURLToPath(
+    new URL("./bun_project_matrix.json", import.meta.url),
+  );
+  const result = parseConfig(configPath);
+  if (result !== null) {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}

--- a/json2vars_setter/features/matrix_update.py
+++ b/json2vars_setter/features/matrix_update.py
@@ -285,6 +285,11 @@ Examples:
         help="Strategy for Deno versions",
     )
     parser.add_argument(
+        "--bun",
+        choices=["stable", "latest", "both"],
+        help="Strategy for Bun versions",
+    )
+    parser.add_argument(
         "--all",
         choices=["stable", "latest", "both"],
         help="Apply the same strategy to all languages",
@@ -321,6 +326,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         args.dotnet = args.all
         args.java = args.all
         args.deno = args.all
+        args.bun = args.all
 
     # Collect language strategies
     language_strategies: Dict[str, str] = {}
@@ -342,6 +348,8 @@ def main(argv: Optional[List[str]] = None) -> None:
         language_strategies["java"] = args.java
     if args.deno:
         language_strategies["deno"] = args.deno
+    if args.bun:
+        language_strategies["bun"] = args.bun
 
     if not language_strategies:
         parser.error("At least one language strategy must be specified")

--- a/json2vars_setter/version/fetchers/bun.py
+++ b/json2vars_setter/version/fetchers/bun.py
@@ -1,0 +1,193 @@
+import os
+import re
+from typing import List, Tuple, cast
+
+import requests
+
+from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.core.exceptions import ParseError
+from json2vars_setter.version.core.utils import (
+    JsonObject,
+    ReleaseInfo,
+    check_github_api,
+    setup_logging,
+)
+
+# Stable Bun tags look exactly like "bun-v1.3.14"; "canary" and legacy "v0.x"
+# tags do not match this pattern and are therefore excluded.
+_STABLE_TAG_PATTERN = re.compile(r"bun-v\d+\.\d+\.\d+$")
+
+
+class BunVersionFetcher(BaseVersionFetcher):
+    """Fetches Bun version information from GitHub"""
+
+    def __init__(self) -> None:
+        """Initialize with Bun's GitHub repository information"""
+        super().__init__("oven-sh", "bun")
+
+    def _is_stable_tag(self, tag: JsonObject) -> bool:
+        """
+        Check if a tag represents a stable Bun release
+
+        Args:
+            tag: Tag information from GitHub API
+
+        Returns:
+            True if the tag represents a stable release, False otherwise
+        """
+        name = str(tag.get("name", ""))
+
+        # Bun uses format "bun-vX.Y.Z" for stable releases
+        return bool(_STABLE_TAG_PATTERN.fullmatch(name))
+
+    def _parse_version_from_tag(self, tag: JsonObject) -> ReleaseInfo:
+        """
+        Parse version information from a Bun tag
+
+        Args:
+            tag: Tag information from GitHub API
+
+        Returns:
+            Parsed ReleaseInfo object
+
+        Raises:
+            ParseError: If required version information cannot be parsed
+        """
+        name = str(tag.get("name", ""))
+        if not name:
+            raise ParseError("No tag name found")
+
+        # Clean version string (e.g., "bun-v1.3.14" -> "1.3.14")
+        version = name.removeprefix("bun-v")
+
+        # All filtered tags are considered stable
+        prerelease = False
+
+        return ReleaseInfo(
+            version=version,
+            release_date=None,
+            prerelease=prerelease,
+            additional_info={
+                "tag_name": name,
+                "commit": {"sha": cast(JsonObject, tag.get("commit", {})).get("sha")},
+                "tarball_url": tag.get("tarball_url"),
+                "zipball_url": tag.get("zipball_url"),
+            },
+        )
+
+    def _get_stability_criteria(
+        self, releases: List[ReleaseInfo]
+    ) -> Tuple[ReleaseInfo, ReleaseInfo]:
+        """
+        Determine the stable and latest versions of Bun
+
+        - latest: the most recent release version
+        - stable: usually the previous minor version of latest
+
+        Args:
+            releases: List of release information
+
+        Returns:
+            Tuple of (latest_release, stable_release)
+        """
+        if not releases:
+            # Raise an exception to explicitly handle the case where no releases are available
+            raise ValueError("No releases available")
+
+        # The latest version is always the first release
+        latest = releases[0]
+
+        # Get and parse the version number
+        latest_version = latest.version
+        match = re.match(r"(\d+)\.(\d+)\.(\d+)", latest_version)
+
+        if match:
+            major, minor, _patch = map(int, match.groups())
+            # Look for the previous minor version
+            prev_minor = minor - 1
+
+            # Search for a release with the previous minor version
+            for release in releases:
+                r_match = re.match(r"(\d+)\.(\d+)\.(\d+)", release.version)
+                if r_match:
+                    r_major, r_minor, _r_patch = map(int, r_match.groups())
+                    if r_major == major and r_minor == prev_minor:
+                        self.logger.info(
+                            f"Using {release.version} as stable vs latest {latest_version}"
+                        )
+                        return latest, release
+
+        # Use the latest version if no suitable stable version is found
+        self.logger.info(
+            f"No suitable stable version found, using latest {latest_version} as stable"
+        )
+        return latest, latest
+
+
+def bun_filter_func(tag: JsonObject) -> bool:
+    """Filter function for Bun tags in API checker"""
+    name = str(tag.get("name", ""))
+    return bool(_STABLE_TAG_PATTERN.fullmatch(name))
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Fetch Bun version information")
+    parser.add_argument(
+        "--count", type=int, default=5, help="Number of versions to fetch"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="count", default=0, help="Increase verbosity"
+    )
+    args = parser.parse_args()
+
+    # Set up logging
+    logger = setup_logging(args.verbose)
+
+    # Check API directly if in verbose mode
+    if args.verbose > 0:
+        # Create a session for API checking
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "json2vars-setter",
+            }
+        )
+
+        # Add GitHub token if available
+        github_token = os.environ.get("GITHUB_TOKEN")
+        if github_token:
+            session.headers.update({"Authorization": f"token {github_token}"})
+
+        check_github_api(
+            session=session,
+            github_owner="oven-sh",
+            github_repo="bun",
+            count=args.count,
+            filter_func=bun_filter_func,
+        )
+
+    # Display header in verbose mode
+    if args.verbose > 0:
+        print("\n=== Fetching Bun Versions ===")
+
+    # Main processing
+    fetcher = BunVersionFetcher()
+    versions = fetcher.fetch_versions(recent_count=args.count)
+
+    # Output results
+    print(
+        json.dumps(
+            {
+                "latest": versions.latest,
+                "stable": versions.stable,
+                "recent_releases": [vars(r) for r in versions.recent_releases],
+                "details": versions.details,
+            },
+            indent=2,
+        )
+    )

--- a/json2vars_setter/version/registry.py
+++ b/json2vars_setter/version/registry.py
@@ -8,6 +8,7 @@ shared by the matrix-update and version-cache features.
 from typing import Callable, Dict
 
 from json2vars_setter.version.core.base import BaseVersionFetcher
+from json2vars_setter.version.fetchers.bun import BunVersionFetcher
 from json2vars_setter.version.fetchers.deno import DenoVersionFetcher
 from json2vars_setter.version.fetchers.dotnet import DotnetVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
@@ -30,6 +31,7 @@ LANGUAGE_FETCHERS: Dict[str, Callable[[], BaseVersionFetcher]] = {
     "dotnet": DotnetVersionFetcher,
     "java": JavaVersionFetcher,
     "deno": DenoVersionFetcher,
+    "bun": BunVersionFetcher,
 }
 
 

--- a/tests/features/test_matrix_update.py
+++ b/tests/features/test_matrix_update.py
@@ -305,6 +305,7 @@ def test_main_function(mocker: MockerFixture) -> None:
             "dotnet": "stable",
             "java": "stable",
             "deno": "stable",
+            "bun": "stable",
         },
         False,
     )
@@ -326,6 +327,8 @@ def test_main_function(mocker: MockerFixture) -> None:
             "both",
             "--deno",
             "latest",
+            "--bun",
+            "stable",
             "--dry-run",
         ],
     )
@@ -340,6 +343,7 @@ def test_main_function(mocker: MockerFixture) -> None:
             "dotnet": "latest",
             "java": "both",
             "deno": "latest",
+            "bun": "stable",
         },
         True,  # dry_run=True
     )

--- a/tests/version/fetchers/test_bun.py
+++ b/tests/version/fetchers/test_bun.py
@@ -1,0 +1,181 @@
+from typing import List, cast
+
+import pytest
+import pytest_mock
+
+from json2vars_setter.version.core.exceptions import ParseError
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
+from json2vars_setter.version.fetchers.bun import BunVersionFetcher, bun_filter_func
+
+
+@pytest.fixture
+def bun_fetcher() -> BunVersionFetcher:
+    """Fixture to create a BunVersionFetcher instance"""
+    return BunVersionFetcher()
+
+
+def test_init(bun_fetcher: BunVersionFetcher) -> None:
+    """Test __init__ sets the correct GitHub repository information"""
+    assert bun_fetcher.github_owner == "oven-sh"
+    assert bun_fetcher.github_repo == "bun"
+
+
+def test_is_stable_tag(bun_fetcher: BunVersionFetcher) -> None:
+    """Test _is_stable_tag method with various tag scenarios"""
+    stable_tags: List[JsonObject] = [
+        {"name": "bun-v1.3.14"},
+        {"name": "bun-v1.2.23"},
+        {"name": "bun-v1.0.0"},
+    ]
+
+    unstable_tags: List[JsonObject] = [
+        {"name": "canary"},
+        {"name": "not-quite-v0"},
+        {"name": "v0.1.1"},  # legacy format
+        {"name": "bun-v1.3"},  # only two components
+        {"name": "1.3.14"},  # missing prefix
+        {"name": ""},
+    ]
+
+    for tag in stable_tags:
+        assert bun_fetcher._is_stable_tag(tag) is True
+    for tag in unstable_tags:
+        assert bun_fetcher._is_stable_tag(tag) is False
+
+
+def test_parse_version_from_tag(bun_fetcher: BunVersionFetcher) -> None:
+    """Test _parse_version_from_tag method"""
+    valid_tag: JsonObject = {
+        "name": "bun-v1.3.14",
+        "commit": {"sha": "abc123"},
+        "tarball_url": "https://example.com/tarball",
+        "zipball_url": "https://example.com/zipball",
+    }
+
+    release_info: ReleaseInfo = bun_fetcher._parse_version_from_tag(valid_tag)
+
+    assert release_info.version == "1.3.14"
+    assert release_info.prerelease is False
+    assert release_info.additional_info["tag_name"] == "bun-v1.3.14"
+    assert cast(JsonObject, release_info.additional_info["commit"])["sha"] == "abc123"
+    assert release_info.additional_info["tarball_url"] == "https://example.com/tarball"
+    assert release_info.additional_info["zipball_url"] == "https://example.com/zipball"
+
+    with pytest.raises(ParseError):
+        bun_fetcher._parse_version_from_tag({"name": ""})
+
+
+def test_get_stability_criteria(bun_fetcher: BunVersionFetcher) -> None:
+    """Test _get_stability_criteria method"""
+    releases: List[ReleaseInfo] = [
+        ReleaseInfo(version="1.3.14"),
+        ReleaseInfo(version="1.2.23"),
+        ReleaseInfo(version="1.1.40"),
+    ]
+
+    latest, stable = bun_fetcher._get_stability_criteria(releases)
+    assert latest.version == "1.3.14"
+    assert stable.version == "1.2.23"
+
+    single_release: List[ReleaseInfo] = [ReleaseInfo(version="1.3.14")]
+    latest, stable = bun_fetcher._get_stability_criteria(single_release)
+    assert latest.version == "1.3.14"
+    assert stable.version == "1.3.14"
+
+    with pytest.raises(ValueError):
+        bun_fetcher._get_stability_criteria([])
+
+
+def test_bun_filter_func() -> None:
+    """Test bun_filter_func with various tag names"""
+    stable_tags: List[JsonObject] = [
+        {"name": "bun-v1.3.14"},
+        {"name": "bun-v1.2.23"},
+    ]
+    unstable_tags: List[JsonObject] = [
+        {"name": "canary"},
+        {"name": "v0.1.1"},
+        {"name": "bun-v1.3"},
+        {"name": ""},
+    ]
+    for tag in stable_tags:
+        assert bun_filter_func(tag) is True
+    for tag in unstable_tags:
+        assert bun_filter_func(tag) is False
+
+
+def test_fetch_versions_integration(
+    bun_fetcher: BunVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test fetch_versions method with mocked API calls"""
+    mock_tags: List[JsonObject] = [
+        {
+            "name": "bun-v1.3.14",
+            "commit": {"sha": "abc123"},
+            "tarball_url": "https://example.com/tarball/1.3.14",
+            "zipball_url": "https://example.com/zipball/1.3.14",
+        },
+        {
+            "name": "bun-v1.2.23",
+            "commit": {"sha": "def456"},
+            "tarball_url": "https://example.com/tarball/1.2.23",
+            "zipball_url": "https://example.com/zipball/1.2.23",
+        },
+    ]
+
+    mocker.patch.object(bun_fetcher, "_get_github_tags", return_value=mock_tags)
+
+    versions = bun_fetcher.fetch_versions(recent_count=2)
+
+    assert versions.latest == "1.3.14"
+    assert versions.stable == "1.2.23"
+    assert len(versions.recent_releases) == 2
+    assert "fetch_time" in versions.details
+    assert versions.details["source"] == "github:oven-sh/bun"
+
+
+def test_get_stability_criteria_invalid_latest_version(
+    bun_fetcher: BunVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria when the latest version is unparsable"""
+    mocker.patch.object(bun_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="invalid"),
+        ReleaseInfo(version="1.2.23"),
+    ]
+    latest, stable = bun_fetcher._get_stability_criteria(releases)
+    assert latest.version == "invalid"
+    assert stable.version == "invalid"
+
+
+def test_get_stability_criteria_no_previous_minor(
+    bun_fetcher: BunVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria when no previous minor version exists"""
+    mocker.patch.object(bun_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="1.3.14"),
+        ReleaseInfo(version="1.3.13"),  # same minor
+        ReleaseInfo(version="0.9.0"),  # different major
+    ]
+    latest, stable = bun_fetcher._get_stability_criteria(releases)
+    assert latest.version == "1.3.14"
+    assert stable.version == "1.3.14"
+
+
+def test_get_stability_criteria_invalid_release_version(
+    bun_fetcher: BunVersionFetcher, mocker: "pytest_mock.MockerFixture"
+) -> None:
+    """Test _get_stability_criteria with an invalid version in the releases list"""
+    mocker.patch.object(bun_fetcher, "logger", mocker.Mock())
+
+    releases = [
+        ReleaseInfo(version="1.3.14"),
+        ReleaseInfo(version="1.2.invalid"),  # skipped
+        ReleaseInfo(version="1.2.23"),
+    ]
+    latest, stable = bun_fetcher._get_stability_criteria(releases)
+    assert latest.version == "1.3.14"
+    assert stable.version == "1.2.23"

--- a/tests/version/test_registry.py
+++ b/tests/version/test_registry.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from json2vars_setter.version.fetchers.bun import BunVersionFetcher
 from json2vars_setter.version.fetchers.deno import DenoVersionFetcher
 from json2vars_setter.version.fetchers.dotnet import DotnetVersionFetcher
 from json2vars_setter.version.fetchers.go import GoVersionFetcher
@@ -25,6 +26,7 @@ def test_get_version_fetcher_returns_expected_type() -> None:
     assert isinstance(get_version_fetcher("dotnet"), DotnetVersionFetcher)
     assert isinstance(get_version_fetcher("java"), JavaVersionFetcher)
     assert isinstance(get_version_fetcher("deno"), DenoVersionFetcher)
+    assert isinstance(get_version_fetcher("bun"), BunVersionFetcher)
 
 
 def test_get_version_fetcher_unsupported_language() -> None:


### PR DESCRIPTION
## Overview

Adds **Bun** as a supported language for dynamic version management, mirroring the recently merged Deno support (#514). Follows the full "Adding a New Language" checklist in `CLAUDE.md`.

## Changes

- **Fetcher** (`json2vars_setter/version/fetchers/bun.py`): parses `oven-sh/bun` tags (`bun-vX.Y.Z`), excluding `canary` and legacy `v0.x` tags. `stable` = previous minor of `latest`.
- **Registry**: register `BunVersionFetcher` in `json2vars_setter/version/registry.py`.
- **Matrix update CLI**: `--bun` strategy in `features/matrix_update.py` (incl. `--all` wiring).
- **Action contract** (`action.yml`): `bun-strategy` input, `versions_bun` output, strategy-arg block, summary echo.
- **Tests**: `tests/version/fetchers/test_bun.py` (100% coverage) + additions to `test_registry.py` and `test_matrix_update.py`.
- **Example project** (`examples/bun/`): Bun (`bun:test`) JSON-parser project + matrix + README.
- **Example CI** (`.github/workflows/bun_test.yml`): uses `oven-sh/setup-bun` (pinned). Set ups action via `uses: ./` per the two-phase ref-swap rule (tag swap is a tracked follow-up after the release that adds Bun).
- **Badges + docs**: status badges in `README.md` / `docs/index.md` (gist `431a19225ef80b473e7eee8e060b7516`), plus prose in `docs/features/dynamic-update.md`, `docs/reference/options.md`, `docs/reference/version-sources.md`, and `CLAUDE.md`.

## Verification

- `pytest`: **248 passed**, `bun.py` coverage **100%**
- `ruff check` / `ruff format --check`: pass
- `mypy`: clean

## Follow-up (after release)

Per CLAUDE.md item 9, once the release that adds Bun ships, swap `bun_test.yml` from `uses: ./` to the pinned tag `uses: 7rikazhexde/json2vars-setter@vX.Y.Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
