### PR TITLE
:pushpin: Pin deno_test.yml and bun_test.yml to json2vars-setter@v1.7.0

### DIFF
--- a/.github/workflows/bun_test.yml
+++ b/.github/workflows/bun_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Bun): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.7.0
         with:
           json-file: examples/bun/bun_project_matrix.json
 

--- a/.github/workflows/deno_test.yml
+++ b/.github/workflows/deno_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Deno): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.7.0
         with:
           json-file: examples/deno/deno_project_matrix.json
 


### PR DESCRIPTION
Second phase of the two-phase action-reference rule (CLAUDE.md "Adding a New Language", point 9).

Deno (#514) and Bun (#516) both shipped in **v1.7.0**, so their `versions_deno` / `versions_bun` outputs now exist in the published tag. Swap both example workflows from the in-repo `uses: ./` back to the pinned tag `uses: 7rikazhexde/json2vars-setter@v1.7.0`, matching every other `*_test.yml`. From here `sync-version-refs.sh` keeps them pinned to the latest release.

Editing each workflow file triggers its own path-filtered run, so this PR validates the pinned ref end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)