### PR TITLE
:lock: Pin swift-actions/setup-swift to v2.4.0 (ignore broken v3 beta)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,4 +86,15 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      # swift-actions/setup-swift v3 is currently only a pre-release
+      # (v3.0.0-beta.1). Its Linux path switched to the Swiftly installer,
+      # which fails GPG signature verification on the runner
+      # ("gpg: Can't check signature: No public key" —
+      # swift-actions/setup-swift#798, still open). The moving `v3` tag points
+      # at that beta, so Dependabot proposes it as if it were a stable major
+      # (see the closed PR #523). Stay on the v2.4.0 stable release; remove
+      # this ignore once a fixed v3 is released as GA.
+      - dependency-name: "swift-actions/setup-swift"
+        versions: ["3.x"]
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What

Pin `swift-actions/setup-swift` to the stable **v2.4.0** and tell Dependabot to ignore the `3.x` line until a fixed GA release ships.

## Why

Dependabot opened #523 bumping `swift-actions/setup-swift` 2.4.0 → `v3`. The moving `v3` tag currently points at the **pre-release `v3.0.0-beta.1`**. That beta switched the Linux install path to the Swiftly installer, which fails GPG signature verification on the runner:

```
Downloading Swiftly
gpg: Signature made Fri Oct 17 15:00:17 2025 UTC
gpg:                using RSA key E813C892820A6FA13755B268F167DF1ACF9CE069
gpg: Can't check signature: No public key
Error: The process '/usr/bin/gpg' failed with exit code 2
```

This is upstream bug [swift-actions/setup-swift#798](https://github.com/swift-actions/setup-swift/issues/798) (still open). The Swift example workflow failed on `ubuntu-latest` for both matrix versions; macOS uses a different install path and passed.

## Change

Add a Dependabot `ignore` for `swift-actions/setup-swift` `3.x` in `.github/dependabot.yml` so the broken pre-release is not re-proposed. We stay on v2.4.0 (no workflow change needed — #523 is being closed unmerged). Remove the ignore once a fixed v3 is released as GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
