### PR TITLE
:recycle: Pin zig/elixir/dart/swift test workflows to @v1.8.0

### DIFF
--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Dart): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.8.0
         with:
           json-file: examples/dart/dart_project_matrix.json
 

--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Elixir): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.8.0
         with:
           json-file: examples/elixir/elixir_project_matrix.json
 

--- a/.github/workflows/swift_test.yml
+++ b/.github/workflows/swift_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Swift): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.8.0
         with:
           json-file: examples/swift/swift_project_matrix.json
 

--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Zig): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.8.0
         with:
           json-file: examples/zig/zig_project_matrix.json
 


### PR DESCRIPTION
## What

Switch the `zig_test.yml`, `elixir_test.yml`, `dart_test.yml` and `swift_test.yml` example workflows from `uses: ./` to the pinned tag `7rikazhexde/json2vars-setter@v1.8.0`.

## Why

This is **phase two** of the two-phase action-reference rule (CLAUDE.md "Adding a New Language", item 9). Each language's `versions_<lang>` output does not exist in the published tag until the release that adds it, so a tag ref would fail on the introducing PR — hence the workflows started on `uses: ./`. **v1.8.0** shipped Zig, Elixir, Dart and Swift, so they can now reference the released tag like every other `*_test.yml`. From here `.github/scripts/sync-version-refs.sh` keeps them pinned to the latest release.

The obsolete `./` TODO comment blocks are removed.

Because this PR edits the workflow files themselves, all four example workflows run here and exercise `json2vars-setter@v1.8.0` end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
