### PR TITLE
:bug: Block setup-swift v3 by update-type, not version range

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,8 +93,12 @@ updates:
       # ("gpg: Can't check signature: No public key" —
       # swift-actions/setup-swift#798, still open). The moving `v3` tag points
       # at that beta, so Dependabot proposes it as if it were a stable major
-      # (see the closed PR #523). Stay on the v2.4.0 stable release; remove
-      # this ignore once a fixed v3 is released as GA.
+      # (see the closed PRs #523/#527). A `versions: ["3.x"]` constraint does
+      # NOT catch a moving major tag (Dependabot reports the bump target as
+      # bare `3`, which a semver-wildcard range fails to match), so block it by
+      # update-type instead: ignore every major bump of this action. Remove
+      # this once a fixed swift-actions/setup-swift v3 is released as GA and
+      # bump the major intentionally.
       - dependency-name: "swift-actions/setup-swift"
-        versions: ["3.x"]
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What

Change the Dependabot ignore for `swift-actions/setup-swift` from a `versions: ["3.x"]` range to `update-types: ["version-update:semver-major"]`.

## Why

The earlier ignore (#524) used `versions: ["3.x"]`, but Dependabot **re-proposed the broken v3 bump anyway** in #527 — opened at 00:41Z, five minutes *after* #524 merged at 00:36Z. So the range never matched.

Root cause: for a **moving major tag** like `v3`, Dependabot reports the bump target as a bare `3`. A semver-wildcard range (`3.x` → `>=3.0.0 <4.0.0`) fails to match the bare `3`, so the `versions` ignore is a no-op for this case.

`update-types: ["version-update:semver-major"]` is the documented, reliable way to suppress a specific action's major bumps, and is exactly the intent here: keep `swift-actions/setup-swift` on the stable **v2.4.0** until a fixed v3 (swift-actions/setup-swift#798) ships as GA, then bump the major intentionally and remove this ignore.

Closing #527 unmerged alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
