### PR TITLE
:bug: Fix mypy strict violations in dart/swift fetcher tests

### DIFF
--- a/tests/version/fetchers/test_dart.py
+++ b/tests/version/fetchers/test_dart.py
@@ -1,9 +1,9 @@
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import pytest
 import pytest_mock
 
-from json2vars_setter.version.core.utils import ReleaseInfo
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
 from json2vars_setter.version.fetchers.dart import DartVersionFetcher
 
 
@@ -16,13 +16,13 @@ def dart_fetcher() -> DartVersionFetcher:
 class _FakeResponse:
     """Minimal stand-in for a requests.Response used in tests"""
 
-    def __init__(self, payload: dict) -> None:
+    def __init__(self, payload: object) -> None:
         self._payload = payload
 
     def raise_for_status(self) -> None:
         return None
 
-    def json(self) -> dict:
+    def json(self) -> object:
         return self._payload
 
 
@@ -171,7 +171,7 @@ def test_list_stable_versions_real_url(
     dart_fetcher: DartVersionFetcher, mocker: "pytest_mock.MockerFixture"
 ) -> None:
     """The listing request targets the Dart archive bucket with the stable prefix"""
-    payload: dict[str, Any] = {"prefixes": _prefixes(["3.12.1"])}
+    payload: JsonObject = {"prefixes": _prefixes(["3.12.1"])}
     mock_get = mocker.patch.object(
         dart_fetcher.session, "get", return_value=_FakeResponse(payload)
     )

--- a/tests/version/fetchers/test_swift.py
+++ b/tests/version/fetchers/test_swift.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 import pytest_mock
 
-from json2vars_setter.version.core.utils import ReleaseInfo
+from json2vars_setter.version.core.utils import JsonObject, ReleaseInfo
 from json2vars_setter.version.fetchers.swift import SwiftVersionFetcher
 
 
@@ -26,7 +26,7 @@ class _FakeResponse:
         return self._payload
 
 
-def _entries(names: List[str]) -> List[dict]:
+def _entries(names: List[str]) -> List[JsonObject]:
     """Build swift.org-style release entries for the given names"""
     return [{"name": n, "tag": f"swift-{n}-RELEASE"} for n in names]
 


### PR DESCRIPTION
## What

Make `uv run mypy --config-file=pyproject.toml` (strict + `disallow_any_explicit`) clean across the whole tree by fixing type annotations in the dart/swift fetcher tests added in v1.8.0.

## Errors fixed

- `test_dart.py`: `_FakeResponse` used a bare `dict` (`[type-arg]`) and one payload used explicit `Any` (`[explicit-any]`).
- `test_swift.py`: `_entries` returned `List[dict]` (`[type-arg]`).

## Fix

- `test_swift.py` `_entries` → `List[JsonObject]`.
- `test_dart.py` payload literal → `JsonObject`; `_FakeResponse` payload typed as `object` (mirroring test_swift's already-clean `_FakeResponse`) to avoid `dict` invariance errors when passing concrete `dict[str, list[str]]` payloads.

mypy now reports **no issues in 57 source files**; tests are behavior-unchanged (21 passed). These only surfaced via the tree-wide `uv run mypy` quality command — CI has no blocking tree-wide mypy step and pre-commit checks only changed files — so they did not block the introducing PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
