### PR TITLE
:recycle: Pin julia/crystal/haskell/ocaml test workflows to @v1.9.0

### DIFF
--- a/.github/workflows/crystal_test.yml
+++ b/.github/workflows/crystal_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Crystal): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.9.0
         with:
           json-file: examples/crystal/crystal_project_matrix.json
 

--- a/.github/workflows/haskell_test.yml
+++ b/.github/workflows/haskell_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Haskell): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.9.0
         with:
           json-file: examples/haskell/haskell_project_matrix.json
 

--- a/.github/workflows/julia_test.yml
+++ b/.github/workflows/julia_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds Julia): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.9.0
         with:
           json-file: examples/julia/julia_project_matrix.json
 

--- a/.github/workflows/ocaml_test.yml
+++ b/.github/workflows/ocaml_test.yml
@@ -23,14 +23,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Use the in-repo action so this workflow tests the current code. A new
-        # language's `versions_<lang>` output does not exist in the published tag
-        # until the release that adds it, so a tag ref (@vX.Y.Z) would fail here
-        # until then; `./` keeps the example workflow green from the first PR.
-        # TODO(after the release that adds OCaml): switch to the pinned tag
-        #   `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` to match the other
-        #   *_test.yml workflows (see CLAUDE.md "Adding a New Language").
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.9.0
         with:
           json-file: examples/ocaml/ocaml_project_matrix.json
 


### PR DESCRIPTION
## What

Switch the `julia_test.yml`, `crystal_test.yml`, `haskell_test.yml` and `ocaml_test.yml` example workflows from `uses: ./` to the pinned tag `7rikazhexde/json2vars-setter@v1.9.0`.

## Why

This is **phase two** of the two-phase action-reference rule (CLAUDE.md "Adding a New Language", item 9). Each language's `versions_<lang>` output does not exist in the published tag until the release that adds it, so a tag ref would fail on the introducing PR — hence the workflows started on `uses: ./`. **v1.9.0** shipped Julia, Crystal, Haskell and OCaml, so they can now reference the released tag like every other `*_test.yml`. From here `.github/scripts/sync-version-refs.sh` keeps them pinned to the latest release.

The obsolete `./` TODO comment blocks are removed.

Because this PR edits the workflow files themselves, all four example workflows run here and exercise `json2vars-setter@v1.9.0` end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
