### PR TITLE
:lock: Harden and fix .vscode workspace settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,30 @@
+{
+    // Recommended extensions for this repository (well-known, trusted publishers
+    // only). Installing these resolves the "formatter not installed" warnings in
+    // settings.json and provides the linters/formatters the project and its
+    // language examples rely on. VSCode prompts contributors to install these.
+    "recommendations": [
+        // Core (Python package + tooling)
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "DavidAnson.vscode-markdownlint",
+        "tamasfe.even-better-toml",
+        "redhat.vscode-yaml",
+        "github.vscode-github-actions",
+        "timonwong.shellcheck",
+        // Language examples (examples/<lang>/)
+        "esbenp.prettier-vscode",
+        "Shopify.ruby-lsp",
+        "golang.go",
+        "rust-lang.rust-analyzer"
+    ],
+    // Discourage extensions that overlap/conflict with the project's chosen
+    // tooling (Ruff replaces Black/isort/Flake8/Pylint for this repo).
+    "unwantedRecommendations": [
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "ms-python.flake8",
+        "ms-python.pylint"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,8 +54,9 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
     },
-    "javascript.validate.enable": false, // ESLintでのチェックに一任するためにVSCodeのJavaScriptバリデーションを無効化
-    "typescript.validate.enable": false,
+    // ESLintでのチェックに一任するため VSCode の JS/TS バリデーションを無効化
+    // (javascript.validate.enable / typescript.validate.enable は非推奨。統合キーを使用)
+    "js/ts.validate.enabled": false,
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": "explicit" // ESLintによるすべての修正を保存時に実行
     },
@@ -112,6 +113,23 @@
     "github-actions.workflows.pinned.workflows": [
         ".github/workflows/dependabot_prch.yml",
         ".github/workflows/prch_test_matrix_json.yml",
-        ".github/workflows/update-version-and-release.yml"
-    ]
+        ".github/workflows/semantic-release.yml"
+    ],
+    // markdownlint: 自動生成の CHANGELOG.md は除外（.markdownlintignore と整合）
+    "markdownlint.ignore": [
+        "CHANGELOG.md"
+    ],
+    // --- セキュリティ強化 (Node.js / npm サプライチェーン対策) ---
+    // VSCode が npm レジストリから @types を自動取得しないようにする
+    // (Automatic Type Acquisition 経由の供給網リスクを低減)
+    "typescript.disableAutomaticTypeAcquisition": true,
+    // package.json の npm スクリプトを自動検出・実行候補にしない
+    "npm.autoDetect": "off",
+    // フォルダを開いた際に tasks.json のタスクを自動実行しない
+    "task.allowAutomaticTasks": "off",
+    // Workspace Trust を有効に保ち、信頼されていないファイルは常にプロンプト
+    "security.workspace.trust.enabled": true,
+    "security.workspace.trust.untrustedFiles": "prompt",
+    // 拡張機能の自動更新を無効化し、更新内容を明示的に確認する
+    "extensions.autoUpdate": false
 }


### PR DESCRIPTION
## What

Fix the warnings in `.vscode/settings.json`, apply the markdownlint CHANGELOG exclusion in-editor, and add Node.js/npm supply-chain-conscious hardening.

## Warnings fixed

- **Deprecated setting** — `javascript.validate.enable` / `typescript.validate.enable` → single `js/ts.validate.enabled`.
- **Stale pinned workflow** — `update-version-and-release.yml` (does not exist) → `semantic-release.yml`.
- **"Formatter not installed" warnings** (prettier / ruby-lsp / go / rust) — added `.vscode/extensions.json` recommending those (trusted publishers); the warnings clear once the recommended extensions are installed.

## markdownlint exclusion in-editor

- `"markdownlint.ignore": ["CHANGELOG.md"]` so the editor matches `.markdownlintignore` (CHANGELOG is generated by semantic-release).

## Security hardening (recent npm/Node.js supply-chain incidents)

- `typescript.disableAutomaticTypeAcquisition: true` — VSCode will not auto-fetch `@types/*` from npm (closes an ATA supply-chain vector).
- `npm.autoDetect: off`, `task.allowAutomaticTasks: off` — nothing auto-runs on folder open.
- Explicit Workspace Trust (`security.workspace.trust.enabled` / `untrustedFiles: prompt`).
- `extensions.autoUpdate: false` — extension updates are reviewed, not applied silently.
- `extensions.json` recommends only well-known publishers and marks Black/isort/Flake8/Pylint as **unwanted** (Ruff is canonical here).

Workspace-config only; no source or workflow changes. (GitHub Actions are already SHA-pinned; workflow-level hardening is handled separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
