### PR TITLE
:lock: Force JS actions onto Node.js 24 (clear Node 20 deprecation)

### DIFF
--- a/.github/workflows/bun_test.yml
+++ b/.github/workflows/bun_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/bun/**'
       - '.github/workflows/bun_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/crystal_test.yml
+++ b/.github/workflows/crystal_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/crystal/**'
       - '.github/workflows/crystal_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/dart/**'
       - '.github/workflows/dart_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/deno_test.yml
+++ b/.github/workflows/deno_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/deno/**'
       - '.github/workflows/deno_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot_prch.yml
+++ b/.github/workflows/dependabot_prch.yml
@@ -24,6 +24,12 @@ on:
     branches:
       - main
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     if: github.actor == 'dependabot[bot]' && !startsWith(github.event.pull_request.title, 'Bump version')

--- a/.github/workflows/dotnet_test.yml
+++ b/.github/workflows/dotnet_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/dotnet/**'
       - '.github/workflows/dotnet_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/elixir/**'
       - '.github/workflows/elixir_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/go/**'
       - '.github/json2vars-setter/go_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/haskell_test.yml
+++ b/.github/workflows/haskell_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/haskell/**'
       - '.github/workflows/haskell_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/java/**'
       - '.github/workflows/java_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/julia_test.yml
+++ b/.github/workflows/julia_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/julia/**'
       - '.github/workflows/julia_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs_test.yml
+++ b/.github/workflows/nodejs_test.yml
@@ -9,6 +9,12 @@ on:
       - '.github/workflows/nodejs_test.yml'
       - '.github/json2vars-setter/nodejs_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/ocaml_test.yml
+++ b/.github/workflows/ocaml_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/ocaml/**'
       - '.github/workflows/ocaml_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/php/**'
       - '.github/workflows/php_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/prch_test_matrix_json.yml
+++ b/.github/workflows/prch_test_matrix_json.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     if: github.actor != 'dependabot[bot]' && !startsWith(github.event.pull_request.title, 'Bump version')

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -11,6 +11,12 @@ on:
       - 'uv.lock'
       - '.github/json2vars-setter/python_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/ruby/**'
       - '.github/json2vars-setter/ruby_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/rust/**'
       - '.github/json2vars-setter/rust_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/swift_test.yml
+++ b/.github/workflows/swift_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/swift/**'
       - '.github/workflows/swift_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -8,6 +8,12 @@ on:
       - 'examples/zig/**'
       - '.github/workflows/zig_test.yml'
 
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+# Some pinned actions (szenius/set-timezone, mlugg/setup-zig, swift-actions/setup-swift)
+# have no Node 24 release yet; this forces them onto Node 24 per GitHub guidance.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` (workflow-level `env`) in the 20 workflows that use JavaScript actions still shipping on the deprecated Node.js 20 runtime.

## Why

GitHub is deprecating Node.js 20 for JS actions (forced to Node 24 on **2026-06-16**, Node 20 removed **2026-09-16**). An audit of every action used in the repo found these three have **no Node 24 release available**:

| Action | Latest | Runtime | Used by |
|--------|--------|---------|---------|
| `szenius/set-timezone` | v2.0 (latest) | node20 | every `*_test.yml` (Set timezone) |
| `mlugg/setup-zig` | v2.2.1 (latest) | node20 | `zig_test.yml` |
| `swift-actions/setup-swift` | v2.4.0 (stable latest) | node20 | `swift_test.yml` (v3 is the broken pre-release) |

All other actions are already on node24 (checkout v6.0.3, setup-python v6.2.0, cache v5, …) or are composite.

Since no node24 versions exist to bump to, GitHub's documented remedy is the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var, applied here at the workflow level. This clears the deprecation warnings now, with no behavior change. When upstream ships node24 releases, the env can be dropped and the actions bumped.

## Scope

All `*_test.yml` (18) plus `dependabot_prch.yml` and `prch_test_matrix_json.yml` (both use set-timezone). Because each `*_test.yml` is modified, the corresponding example workflow runs on this PR and validates the change end to end.

## Note on the GitHub Pages warning

The Pages deprecation warning originally reported comes from GitHub's **managed `pages-build-deployment`** workflow (triggered by pushing to the `gh-pages` branch via peaceiris), which uses `actions/checkout@v4` + `actions/upload-artifact@v4` and is **not editable** from this repo. That is addressed separately by migrating `deploy.yml` to the Actions-native Pages deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
