### PR TITLE
:lock: Migrate Pages deploy to Actions-native deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,22 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - 'zensical.toml'
+  workflow_dispatch:
 
+# Least-privilege token. The Actions-native Pages deployment needs pages:write
+# and id-token:write; the build only needs to read the repository.
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent Pages deployment; let an in-progress run finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -24,10 +34,6 @@ jobs:
         uses: 7rikazhexde/json2vars-setter@v1.9.0
         with:
           json-file: .github/json2vars-setter/sample/cicd_matrix.json
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 33836132+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ fromJson(steps.json2vars.outputs.versions_python)[0] }}
@@ -48,8 +54,18 @@ jobs:
         run: uv sync --frozen
       - name: Build documentation
         run: uv run zensical build --clean
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+          path: ./site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## What

Migrate `deploy.yml` from the `peaceiris/actions-gh-pages` (gh-pages branch) approach to the **Actions-native GitHub Pages deployment**.

## Why

The GitHub Pages Node.js 20 deprecation warning comes from GitHub's **managed `pages-build-deployment`** workflow, which is triggered when the built site is pushed to the `gh-pages` branch and runs `actions/checkout@v4` + `actions/upload-artifact@v4` on the deprecated Node 20 runtime. That workflow is GitHub-managed and **not editable** from this repo.

Publishing directly from an Actions artifact removes the gh-pages branch round-trip, so the legacy `pages-build-deployment` no longer runs and the warning disappears.

## Changes

- **build** job: existing zensical build → `actions/upload-pages-artifact@v5`.
- **deploy** job: `actions/deploy-pages@v5` with the `github-pages` environment.
- Least-privilege `permissions` (`contents: read`, `pages: write`, `id-token: write`) instead of the previous `contents: write`.
- `concurrency: pages` + `workflow_dispatch` (manual deploys).
- All actions pinned to commit SHAs on Node 24 (or composite).

## Required settings change

This needs the repository **Pages source = "GitHub Actions"** (`build_type: workflow`; currently `legacy`/gh-pages). After that and merge, the workflow can be run via `workflow_dispatch` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
