### PR TITLE
:recycle: Align mypy python_version with the 3.10 support floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,11 @@ extend-exclude = [
 
 [tool.mypy]
 files = ["json2vars_setter", "tests", "scripts"]
-python_version = "3.12"
+# Match the project's minimum supported runtime (requires-python = ">=3.10" and
+# ruff target-version = "py310"). mypy's python_version is the *lowest* version
+# the code must run on, not the newest — setting it to 3.10 makes mypy flag any
+# syntax/stdlib API unavailable on 3.10/3.11 across the whole support range.
+python_version = "3.10"
 # Strict mode + an explicit ban on the Any type (project-wide, incl. tests).
 strict = true
 disallow_any_explicit = true


### PR DESCRIPTION
## What

Change `[tool.mypy] python_version` from `3.12` to **`3.10`**.

## Why

mypy's `python_version` declares the **minimum** Python version the code must run on — it tells mypy which syntax / stdlib APIs are *allowed*, not which runtime is newest. The project already supports `>=3.10`:

- `requires-python = ">=3.10"`
- ruff `target-version = "py310"`

mypy was the lone outlier at `3.12`. With `3.12`, mypy would silently accept 3.11+/3.12+-only constructs (e.g. PEP 695 `type` statements, `itertools.batched`) that break on 3.10/3.11 — defeating the point of checking against the support floor. Pinning mypy to `3.10` aligns all three settings and guarantees type-safety across the whole supported range.

## Verification

`uv run mypy --strict --config-file=pyproject.toml` → **no issues found in 63 source files** (both before and after), confirming the codebase is already 3.10-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)