### PR TITLE
:recycle: Drop unused pytest-xdist and fix the broken just usage recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ or the addition is incomplete:
 - **Linting**: Ruff with E, F, I rules (E402 and E501 ignored)
 - **Type checking**: mypy with strict settings (`disallow_untyped_defs`, `warn_return_any`)
 - **Test coverage**: Minimum 95%, goal 100%. Branch coverage is disabled in config due to testmon compatibility
-- **Testing framework**: pytest with pytest-mock, pytest-cov, pytest-xdist
+- **Testing framework**: pytest with pytest-mock, pytest-cov
 
 ## Versioning Rule
 

--- a/justfile
+++ b/justfile
@@ -46,7 +46,8 @@ install-hooks:
 pre-commit:
     uv run pre-commit run --all-files
 
-# Show CLI usage for the cache / dynamic-update modules
+# Show CLI usage (task guide + per-command options)
 usage:
-    uv run python json2vars_setter/cache_version_info.py --help
-    uv run python json2vars_setter/update_matrix_dynamic.py --help
+    uv run json2vars usage
+    uv run json2vars update-matrix --help
+    uv run json2vars cache-version --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dev = [
     "pytest>=9.0.3,<10.0.0",
     "pre-commit>=4.5.1,<5.0.0",
     "pytest-cov>=7.1.0,<8.0.0",
-    "pytest-xdist>=3.8.0,<4.0.0",
     "pytest-html>=4.2.0,<5.0.0",
     "pytest-mock>=3.15.1,<4.0.0",
     "pytest-testmon>=2.1.4,<3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -348,15 +348,6 @@ wheels = [
 ]
 
 [[package]]
-name = "execnet"
-version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -422,7 +413,6 @@ dev = [
     { name = "pytest-html" },
     { name = "pytest-mock" },
     { name = "pytest-testmon" },
-    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-requests" },
     { name = "zensical" },
@@ -443,7 +433,6 @@ dev = [
     { name = "pytest-html", specifier = ">=4.2.0,<5.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1,<4.0.0" },
     { name = "pytest-testmon", specifier = ">=2.1.4,<3.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
     { name = "ruff", specifier = ">=0.15.10,<0.16.0" },
     { name = "types-requests", specifier = ">=2.32.0,<3.0.0" },
     { name = "zensical", specifier = ">=0.0.32,<0.0.45" },
@@ -881,19 +870,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4d/1d/3e4230cc67cd6205bbe03c3527500c0ccaf7f0c78b436537eac71590ee4a/pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51", size = 23108, upload-time = "2025-12-01T07:30:24.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b", size = 25199, upload-time = "2025-12-01T07:30:23.623Z" },
-]
-
-[[package]]
-name = "pytest-xdist"
-version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Performance-tooling review (the "Astral/Rust perf tooling" follow-up). Conclusion: **nothing worth adding.** The modern stack is already comprehensive (uv, ruff, ty, typos, zizmor, zensical), and the test suite is fast — **331 tests in ~1.25s**.

## Changes

**Remove unused `pytest-xdist`**
- It was a declared dev dependency that **nothing ever invoked** (no `-n auto`, no addopts, no config).
- Measured `pytest -n auto`: **~5s vs ~1.25s serial** — i.e. ~4× *slower*, because worker-spawn + per-worker collection overhead dwarfs a sub-second suite.
- Dropping it (and its transitive `execnet`) slims the dev env and supply-chain surface: `uv.lock` 53 → 51 packages.

**Fix the broken `just usage` recipe**
- It pointed at `json2vars_setter/cache_version_info.py` and `update_matrix_dynamic.py`, which were renamed into `features/` long ago — so `just usage` was broken.
- Repointed at the real Typer CLI: `json2vars usage` + per-command `--help`.

## Verification

- `uv run pytest -q` → **331 passed in ~1.27s**
- `uv run json2vars usage` runs correctly
- `uv lock --offline` → 51 packages, no `pytest-xdist`/`execnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)