### PR TITLE
:memo: Add runnable single-source-of-truth sample workflow + local try guide

### DIFF
--- a/.github/workflows/sample_single_source.yml
+++ b/.github/workflows/sample_single_source.yml
@@ -1,0 +1,81 @@
+name: Sample - Single Source of Truth
+
+# A runnable, real-world demonstration of the core value of json2vars-setter:
+# define your build matrix ONCE in a JSON file, then consume it from multiple
+# independent jobs — no version lists copy-pasted across jobs or workflows.
+#
+# This workflow runs in THIS repository, so its green check is living proof you
+# can reproduce in your own project:
+#   1. Copy examples/showcase/matrix.json and this workflow into your repo.
+#   2. Edit the JSON (OS list / Python versions) to taste.
+#   3. Push — the same green result you see here is what you get.
+# See examples/showcase/README.md for the step-by-step adoption guide.
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'examples/showcase/**'
+      - '.github/workflows/sample_single_source.yml'
+  workflow_dispatch:
+
+# Opt JavaScript actions into Node.js 24 (deprecation of Node 20 on runners).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  # Step 1: read the matrix from the single JSON file and expose it as outputs.
+  set_variables:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.json2vars.outputs.os }}
+      versions_python: ${{ steps.json2vars.outputs.versions_python }}
+      ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set variables from JSON
+        id: json2vars
+        uses: 7rikazhexde/json2vars-setter@v1.9.1
+        with:
+          json-file: examples/showcase/matrix.json
+
+  # Consumer #1: a full OS x Python test matrix, built entirely from the JSON.
+  # Nothing here repeats the version list — it all comes from set_variables.
+  test:
+    needs: set_variables
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.set_variables.outputs.os) }}
+        python-version: ${{ fromJson(needs.set_variables.outputs.versions_python) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run a trivial check on this matrix leg
+        run: python -c "import sys; print('matrix leg OK:', sys.version)"
+
+  # Consumer #2: a DIFFERENT job reusing the SAME outputs without redefining
+  # them — e.g. a lint/docs job that only needs the lowest supported Python.
+  lint:
+    needs: set_variables
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up the lowest supported Python from the shared matrix
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ fromJson(needs.set_variables.outputs.versions_python)[0] }}
+
+      - name: Show that this job reuses the single source of truth
+        run: |
+          echo "One JSON, consumed by an independent job:"
+          echo "  OS list:         ${{ needs.set_variables.outputs.os }}"
+          echo "  Python list:     ${{ needs.set_variables.outputs.versions_python }}"
+          echo "  Pinned for lint: ${{ fromJson(needs.set_variables.outputs.versions_python)[0] }}"
+          echo "  Pages branch:    ${{ needs.set_variables.outputs.ghpages_branch }}"

--- a/.github/workflows/sample_single_source.yml
+++ b/.github/workflows/sample_single_source.yml
@@ -79,3 +79,40 @@ jobs:
           echo "  Python list:     ${{ needs.set_variables.outputs.versions_python }}"
           echo "  Pinned for lint: ${{ fromJson(needs.set_variables.outputs.versions_python)[0] }}"
           echo "  Pages branch:    ${{ needs.set_variables.outputs.ghpages_branch }}"
+
+  # Publish the status badge shown in README.md / docs/index.md — the trust
+  # signal that lets users see this sample is genuinely green without opening
+  # the Actions tab. Mirrors the per-language *_test.yml badge jobs.
+  update_badge:
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Determine status and color
+        id: status
+        shell: bash
+        run: |
+          # 'passing' only when both consumers (test matrix + lint) succeeded.
+          if [ "${{ needs.test.result }}" = "success" ] && [ "${{ needs.lint.result }}" = "success" ]; then
+            status=passing;   color=2ea44f
+          elif [ "${{ needs.test.result }}" = "cancelled" ] || [ "${{ needs.lint.result }}" = "cancelled" ]; then
+            status=cancelled; color=808080
+          else
+            status=failing;   color=cf222e
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
+
+      - name: Create badge
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 43c16c21c735a80b673a65e1bb0d9619
+          filename: sample-single-source-badge.json
+          label: "Sample: Single Source"
+          message: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          labelColor: "24292f"
+          style: "flat"
+          namedLogo: "github"
+          logoColor: "white"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ By centralizing your configuration in JSON files, you gain the ability to easily
   - [Table of Contents](#table-of-contents)
   - [Key Features](#key-features)
   - [Supported Matrix Components](#supported-matrix-components)
+  - [Sample Workflows](#sample-workflows)
   - [Quick Start](#quick-start)
   - [Components](#components)
   - [Documentation](#documentation)
@@ -51,6 +52,14 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![Crystal](https://img.shields.io/badge/Crystal-000000?style=flat&logo=crystal&logoColor=white) | [![install-crystal](https://img.shields.io/badge/install--crystal-000000?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/install-crystal) | [![Crystal Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/09c90cf4e8e97865f6213085c82716e4/raw/crystal-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/crystal_test.yml) |
 | ![Haskell](https://img.shields.io/badge/Haskell-5e5086?style=flat&logo=haskell&logoColor=white) | [![setup-haskell](https://img.shields.io/badge/setup--haskell-5e5086?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-haskell) | [![Haskell Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/ac694a2ecdc91ee32dda6afa49863aa4/raw/haskell-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/haskell_test.yml) |
 | ![OCaml](https://img.shields.io/badge/OCaml-EC6813?style=flat&logo=ocaml&logoColor=white) | [![setup-ocaml](https://img.shields.io/badge/setup--ocaml-EC6813?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/set-up-ocaml) | [![OCaml Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/ac8d039239f77264250f852a38143043/raw/ocaml-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/ocaml_test.yml) |
+
+## Sample Workflows
+
+Beyond the per-language tests above, these **runnable use-case samples** live in this repository and execute on real GitHub Actions. The green badge is proof you can reproduce the result, then copy the files into your own project — no local setup required to gain confidence.
+
+| Use case | Status | What it demonstrates | Files |
+|----------|--------|----------------------|-------|
+| Single source of truth | [![Sample: Single Source of Truth](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/43c16c21c735a80b673a65e1bb0d9619/raw/sample-single-source-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/sample_single_source.yml) | One JSON parsed once, then consumed by an independent `test` matrix **and** a separate `lint` job — define versions in one place, use them everywhere | [workflow](.github/workflows/sample_single_source.yml) · [example](examples/showcase) |
 
 ## Quick Start
 

--- a/docs/examples/troubleshooting.md
+++ b/docs/examples/troubleshooting.md
@@ -189,14 +189,15 @@ Or use the built-in debug output:
 
 ### Test Configurations Locally
 
-You can test the scripts locally before using them in GitHub Actions:
+You can run the same engines locally with the `json2vars` CLI before using them in
+GitHub Actions (in a clone, prefix with `uv run`):
 
 ```bash
-# Test version_cache.py
-python path/to/version_cache.py --template-only --verbose
+# Version cache (the engine behind the caching feature)
+json2vars cache-version --template-only --verbose
 
-# Test matrix_update.py
-python path/to/matrix_update.py --json-file ./matrix.json --all stable --dry-run
+# Matrix update (the engine behind the dynamic-update feature)
+json2vars update-matrix --json-file ./matrix.json --all stable --dry-run
 ```
 
 ### Inspect Generated Files

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,58 @@ This guide will help you set up and use the JSON to Variables Setter action in y
 
 As this is a GitHub Action, there's no installation required. You simply reference the action in your workflow file.
 
+## Try It Locally (No GitHub Needed)
+
+Before wiring the action into a workflow, you can run the **exact same parsing logic** on your own machine and see precisely which outputs it would expose. The package ships a `json2vars` CLI. Inside a workflow the action writes its outputs to the file named by `$GITHUB_OUTPUT`; locally that is simply a file path you choose, so you can open it and read the result.
+
+### Step 1: Create a small matrix file
+
+Save this as `matrix.json`:
+
+```json
+{
+  "os": ["ubuntu-latest", "macos-latest"],
+  "versions": { "python": ["3.12", "3.13"] },
+  "ghpages_branch": "gh-pages"
+}
+```
+
+### Step 2: Run the parser
+
+From a clone of this repository (uses [uv](https://docs.astral.sh/uv/)):
+
+```bash
+uv sync
+GITHUB_OUTPUT=out.txt uv run json2vars parse matrix.json
+```
+
+Or without cloning — `uvx` fetches and runs the CLI straight from GitHub:
+
+```bash
+GITHUB_OUTPUT=out.txt uvx --from git+https://github.com/7rikazhexde/json2vars-setter json2vars parse matrix.json
+```
+
+### Step 3: Inspect the outputs
+
+```bash
+cat out.txt
+```
+
+```text
+OS=["ubuntu-latest", "macos-latest"]
+OS_0=ubuntu-latest
+OS_1=macos-latest
+VERSIONS_PYTHON=["3.12", "3.13"]
+VERSIONS_PYTHON_0=3.12
+VERSIONS_PYTHON_1=3.13
+GHPAGES_BRANCH=gh-pages
+```
+
+Each line is one workflow output: the full JSON list (`VERSIONS_PYTHON`), each indexed element (`VERSIONS_PYTHON_0`, `VERSIONS_PYTHON_1`), and scalars such as `GHPAGES_BRANCH`. This is exactly what `${{ steps.json2vars.outputs.* }}` reads when the action runs in a workflow — so what you see locally is what you get in CI.
+
+!!! tip "Explore the other commands"
+    Run `json2vars usage` for a task-oriented guide. Beyond `parse`, the CLI also exposes `update-matrix` (rewrite the matrix file with the latest/stable versions fetched from upstream) and `cache-version` (maintain a version cache) — the same engines behind the action's [dynamic update](features/dynamic-update.md) and [version caching](features/version-caching.md) features. Those two reach out to GitHub APIs, so set `GITHUB_TOKEN` to avoid rate limits.
+
 ## Basic Setup
 
 ### Step 1: Create a JSON Configuration File

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,14 @@ By centralizing your configuration in JSON files, you gain the ability to easily
 | ![Haskell](https://img.shields.io/badge/Haskell-5e5086?style=flat&logo=haskell&logoColor=white) | [![setup-haskell](https://img.shields.io/badge/setup--haskell-5e5086?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/setup-haskell) | [![Haskell Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/ac694a2ecdc91ee32dda6afa49863aa4/raw/haskell-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/haskell_test.yml) |
 | ![OCaml](https://img.shields.io/badge/OCaml-EC6813?style=flat&logo=ocaml&logoColor=white) | [![setup-ocaml](https://img.shields.io/badge/setup--ocaml-EC6813?style=flat&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/set-up-ocaml) | [![OCaml Test](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/ac8d039239f77264250f852a38143043/raw/ocaml-test-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/ocaml_test.yml) |
 
+## Sample Workflows
+
+Beyond the per-language tests above, these **runnable use-case samples** live in the repository and execute on real GitHub Actions. The green badge is proof you can reproduce the result, then copy the files into your own project — no local setup required to gain confidence.
+
+| Use case | Status | What it demonstrates | Files |
+|----------|--------|----------------------|-------|
+| Single source of truth | [![Sample: Single Source of Truth](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/7rikazhexde/43c16c21c735a80b673a65e1bb0d9619/raw/sample-single-source-badge.json&cacheSeconds=0)](https://github.com/7rikazhexde/json2vars-setter/actions/workflows/sample_single_source.yml) | One JSON parsed once, then consumed by an independent `test` matrix **and** a separate `lint` job — define versions in one place, use them everywhere | [workflow](https://github.com/7rikazhexde/json2vars-setter/blob/main/.github/workflows/sample_single_source.yml) · [example](https://github.com/7rikazhexde/json2vars-setter/tree/main/examples/showcase) |
+
 ## Quick Start
 
 !!! info "See [Basic Usage Examples](https://7rikazhexde.github.io/json2vars-setter/examples/basic/) for details."

--- a/examples/showcase/README.md
+++ b/examples/showcase/README.md
@@ -1,0 +1,64 @@
+# Showcase: Single Source of Truth
+
+This is a **runnable, copy-it-and-get-the-same-result** example of the core value
+of json2vars-setter: define your build matrix **once** in a JSON file, then consume
+it from **multiple independent jobs** — no version lists duplicated across jobs or
+workflows.
+
+Unlike a documentation snippet, this example **actually runs in this repository**.
+The [`Sample - Single Source of Truth`](../../.github/workflows/sample_single_source.yml)
+workflow executes on every change here, so its green check is proof you can
+reproduce — not a promise you have to take on faith.
+
+## The two files
+
+| File | Role |
+|------|------|
+| [`matrix.json`](matrix.json) | The single source of truth: OS list + Python versions + Pages branch. |
+| [`../../.github/workflows/sample_single_source.yml`](../../.github/workflows/sample_single_source.yml) | Reads the JSON once (`set_variables`), then two independent jobs (`test`, `lint`) consume it. |
+
+`matrix.json`:
+
+```json
+{
+    "os": ["ubuntu-latest", "macos-latest"],
+    "versions": { "python": ["3.12", "3.13"] },
+    "ghpages_branch": "gh-pages"
+}
+```
+
+## What it demonstrates
+
+- **`set_variables`** parses `matrix.json` and exposes `os`, `versions_python`, and
+  `ghpages_branch` as job outputs.
+- **`test`** builds a full `os × python-version` matrix straight from those outputs —
+  the version list is never repeated.
+- **`lint`** is a *separate* job that reuses the *same* outputs (it pins the lowest
+  supported Python via `versions_python[0]`), showing that one JSON drives many jobs.
+
+Change `matrix.json` and **every** job updates together. That is the single source
+of truth.
+
+## Try it locally first (no GitHub needed)
+
+```bash
+GITHUB_OUTPUT=out.txt uv run json2vars parse examples/showcase/matrix.json
+cat out.txt
+```
+
+You will see exactly the outputs the workflow consumes. See
+[Getting Started → Try It Locally](../../docs/getting-started.md#try-it-locally-no-github-needed)
+for the full walkthrough.
+
+## Adopt it in your project
+
+1. Copy `matrix.json` and `sample_single_source.yml` into your repository
+   (rename / relocate as you like; keep the `json-file:` path pointing at your JSON).
+2. Edit `matrix.json` for the OS and versions you support.
+3. Make `uses: 7rikazhexde/json2vars-setter@vX.Y.Z` point at the
+   [latest release](https://github.com/7rikazhexde/json2vars-setter/releases).
+4. Push. The same green result you see on this repo is what you get.
+
+> Tip: `versions` also accepts `nodejs`, `ruby`, `go`, `rust`, and many more — see
+> [Reference → Options](../../docs/reference/options.md). To keep the versions fresh
+> automatically, layer on [Dynamic Update](../../docs/features/dynamic-update.md).

--- a/examples/showcase/matrix.json
+++ b/examples/showcase/matrix.json
@@ -1,0 +1,13 @@
+{
+    "os": [
+        "ubuntu-latest",
+        "macos-latest"
+    ],
+    "versions": {
+        "python": [
+            "3.12",
+            "3.13"
+        ]
+    },
+    "ghpages_branch": "gh-pages"
+}


### PR DESCRIPTION
## Why

Per-language examples earn trust through a **real, green workflow + badge**. Use-case patterns (single source of truth, monorepo, conditional matrix, …) were only **doc snippets** — a cautious user can't tell "does it really work?". This adds the first **living, CI-validated** use-case sample, so users can copy it, reproduce the same green result, and adopt it (the virtuous cycle).

## What

- **`.github/workflows/sample_single_source.yml`** — a real workflow that runs in THIS repo. One JSON is parsed once (`set_variables`), then two independent jobs consume the same outputs: a full `os × python` `test` matrix, and a separate `lint` job pinning `versions_python[0]`. Proves the single-source-of-truth pattern live.
  - Named with a **`sample_` prefix** because GitHub only scans `.github/workflows/` flatly (no subfolders) — so use cases are distinguished by filename. Future samples: `sample_monorepo.yml`, `sample_conditional_matrix.yml`, etc.
- **`examples/showcase/{matrix.json,README.md}`** — the copy-it-and-adopt sample with a step-by-step guide.
- **`docs/getting-started.md`** — new **"Try It Locally (No GitHub Needed)"**: run the `json2vars` CLI on a small JSON and see the exact outputs locally.
- **`docs/examples/troubleshooting.md`** — fix the stale local-test snippet (pointed at modules long since moved into `features/`) to the real CLI.

## Follow-up (needs you)

The **badge** (README + `docs/index.md`, matching the Python row) needs an **owner-created gist** — it can't be generated programmatically. Give me the gist ID and I'll add the `update_badge` job + README/docs badge to this same PR for full parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)