### PR TITLE
:memo: Add PowerShell variants for local CLI snippets in showcase READMEs

### DIFF
--- a/examples/showcase/dynamic-update/README.md
+++ b/examples/showcase/dynamic-update/README.md
@@ -46,10 +46,21 @@ without touching even the workspace file, add `dry-run: 'true'`.
 
 ## Try it locally
 
+**Linux / macOS (bash):**
+
 ```bash
 # Preview what the update would do, without modifying the file:
 uv run json2vars update-matrix \
   --json-file examples/showcase/dynamic-update/matrix.json \
+  --python stable --nodejs stable --dry-run
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Preview what the update would do, without modifying the file:
+uv run json2vars update-matrix `
+  --json-file examples/showcase/dynamic-update/matrix.json `
   --python stable --nodejs stable --dry-run
 ```
 

--- a/examples/showcase/template/README.md
+++ b/examples/showcase/template/README.md
@@ -32,12 +32,24 @@ its newest 3 cached versions, so a large cache can back a small matrix.
 
 ## Try it locally (no API, no GitHub)
 
+**Linux / macOS (bash):**
+
 ```bash
 uv run json2vars cache-version --template-only \
   --languages python nodejs --output-count 3 \
   --cache-file .github/json2vars-setter/cache/version_cache.json \
   --template-file out-matrix.json
 cat out-matrix.json
+```
+
+**Windows (PowerShell):**
+
+```powershell
+uv run json2vars cache-version --template-only `
+  --languages python nodejs --output-count 3 `
+  --cache-file .github/json2vars-setter/cache/version_cache.json `
+  --template-file out-matrix.json
+Get-Content out-matrix.json
 ```
 
 ## Adopt it

--- a/examples/showcase/version-cache/README.md
+++ b/examples/showcase/version-cache/README.md
@@ -52,6 +52,8 @@ guaranteed hit (deterministic and quota-free). In a real project use a small val
 
 ## Try it locally (no API on a fresh cache)
 
+**Linux / macOS (bash):**
+
 ```bash
 uv run json2vars cache-version \
   --languages python nodejs --output-count 3 \
@@ -59,6 +61,17 @@ uv run json2vars cache-version \
   --cache-file .github/json2vars-setter/cache/version_cache.json \
   --template-file out-matrix.json
 cat out-matrix.json
+```
+
+**Windows (PowerShell):**
+
+```powershell
+uv run json2vars cache-version `
+  --languages python nodejs --output-count 3 `
+  --max-age 3650 `
+  --cache-file .github/json2vars-setter/cache/version_cache.json `
+  --template-file out-matrix.json
+Get-Content out-matrix.json
 ```
 
 ## Adopt it


### PR DESCRIPTION
## Summary

The "Try it locally" code blocks in the showcase READMEs used bash line
continuations (`\`). On Windows those break in PowerShell — PowerShell's
continuation char is a backtick, so each `--flag` line is parsed as a separate
command (`Missing expression after unary operator '--'`).

Add a parallel **Windows (PowerShell)** block (backtick continuation +
`Get-Content`) next to the existing **Linux / macOS (bash)** block in:

- `examples/showcase/version-cache/README.md`
- `examples/showcase/dynamic-update/README.md`
- `examples/showcase/template/README.md`

The `gh pr create` continuation in `docs/examples/ci-cd.md` is inside a workflow
`run:` block (bash on the Linux runner) and is intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)