### PR TITLE
:sparkles: Support all 18 registry languages in cache-version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,12 @@ or the addition is incomplete:
    `_get_stability_criteria`) plus a `<lang>_filter_func` and the `__main__` block,
    modeled on the closest existing fetcher (e.g. `ruby.py` / `go.py`).
 2. **Registry** — register the fetcher in `json2vars_setter/version/registry.py`
-   (`LANGUAGE_FETCHERS`).
+   (`LANGUAGE_FETCHERS`). This map is the **single source of truth** for the supported
+   language set: the version-cache feature derives its `--languages` choices and `all`
+   expansion from it (`SUPPORTED_LANGUAGES = list(LANGUAGE_FETCHERS)` in
+   `features/version_cache.py`), so registering here automatically extends
+   `cache-version` too. **Never hardcode a language list** anywhere that the registry
+   can supply — derive it, the way `version_cache.py` does.
 3. **Matrix update CLI** — `json2vars_setter/features/matrix_update.py`: add the
    `--<lang>` argument, the `args.<lang> = args.all` line in the `--all` block, and
    the `if args.<lang>: language_strategies["<lang>"] = ...` wiring.
@@ -106,7 +111,11 @@ or the addition is incomplete:
    `versions_<lang>` output, the strategy-arg building block, and the summary `echo`.
 5. **Tests (keep 100% coverage)** — `tests/version/fetchers/test_<lang>.py`, plus add
    the language to `tests/version/test_registry.py` and the `--all` / individual-flag
-   assertions in `tests/features/test_matrix_update.py`.
+   assertions in `tests/features/test_matrix_update.py`. The version-cache tests are
+   registry-derived (`test_supported_languages_matches_registry` and the `all`-expansion
+   assertion in `tests/features/test_version_cache.py` reference `LANGUAGE_FETCHERS` /
+   `SUPPORTED_LANGUAGES`), so they pick up the new language automatically — re-run them
+   to confirm, no hardcoded list to edit.
 6. **Example project** — `examples/<lang>/`: a small JSON-parser project with source,
    tests, `<lang>_project_matrix.json`, build config, and `README.md` (mirror
    `examples/ruby/`). The matrix versions must be in the format the language's
@@ -120,8 +129,8 @@ or the addition is incomplete:
    matching badge in `docs/index.md`, pointing at the new gist
    (`gist.githubusercontent.com/7rikazhexde/<GIST_ID>/raw/<lang>-test-badge.json`) and
    the new workflow. Also update any "supported languages" prose (README intro,
-   `docs/features/dynamic-update.md`, `docs/reference/options.md`, this file's
-   Project Overview + fetcher list).
+   `docs/features/dynamic-update.md`, `docs/features/version-caching.md`,
+   `docs/reference/options.md`, this file's Project Overview + fetcher list).
 9. **Release ordering (two-phase action reference)** — a new language's
    `versions_<lang>` output does not exist in the published tag until the release that
    adds it, so a tag ref (`@vX.Y.Z`) in `<lang>_test.yml` would fail on the introducing

--- a/docs/features/version-caching.md
+++ b/docs/features/version-caching.md
@@ -63,8 +63,8 @@ graph TD
 
 !!! tip "\[*1\]: Specify language"
 
-    - Specify languages separated by **spaces**; if `all` is specified, all target languages are retrieved.
-    - Target languages: `python`, `nodejs`, `ruby`, `go`, `rust`
+    - Specify languages separated by **spaces**; if `all` is specified (the default), all target languages are retrieved.
+    - Target languages: `python`, `nodejs`, `ruby`, `go`, `rust`, `php`, `dotnet`, `java`, `deno`, `bun`, `zig`, `elixir`, `dart`, `swift`, `julia`, `crystal`, `haskell`, `ocaml`
 
 !!! tip "\[*2\]: specify a path"
 
@@ -86,7 +86,7 @@ graph TD
 | `--force` | Force update regardless of existing cache | None |
 | `--max-age N` | Update cache only after N days<br>Compares with `last_updated` value in existing cache | 1 day |
 | `--incremental` | Add new versions to existing cache (build history) | None |
-| `--languages` | Specify target languages<br>Separate multiple languages with spaces<br>Supported: python, nodejs, ruby, go, rust | all |
+| `--languages` | Specify target languages<br>Separate multiple languages with spaces<br>Supported: python, nodejs, ruby, go, rust, php, dotnet, java, deno, bun, zig, elixir, dart, swift, julia, crystal, haskell, ocaml | all |
 | `--count N` | Number of versions to fetch and cache per language | 10 |
 | `--output-count N` | Number of versions to include in output template<br>When 0 or not specified, uses the value of `--count` | 0 |
 | `--keep-existing` | Maintain information for non-specified languages | None |
@@ -151,7 +151,7 @@ python json2vars_setter/features/version_cache.py --incremental --count 30
 
 #### Output to specific file
 
-##### Write support language version (python,nodejs,ruby,go,rust)
+##### Write support language version (all supported languages)
 
 ```bash
 python json2vars_setter/features/version_cache.py --template-file ./your_project_matrix.json

--- a/json2vars_setter/features/version_cache.py
+++ b/json2vars_setter/features/version_cache.py
@@ -18,7 +18,7 @@ from json2vars_setter.version.core.utils import (
     VersionInfo,
     get_utc_now,
 )
-from json2vars_setter.version.registry import get_version_fetcher
+from json2vars_setter.version.registry import LANGUAGE_FETCHERS, get_version_fetcher
 
 # Set up logging
 logging.basicConfig(
@@ -36,6 +36,10 @@ DEFAULT_TEMPLATE_FILE = CACHE_DIR / "version_template.json"
 # Default values for matrix.json
 DEFAULT_OS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 DEFAULT_GHPAGES_BRANCH = "gh-pages"
+
+# Supported languages, derived from the central registry so this feature stays
+# in lock-step with matrix-update and the fetchers (single source of truth).
+SUPPORTED_LANGUAGES = list(LANGUAGE_FETCHERS)
 
 
 class VersionCache:
@@ -641,9 +645,9 @@ Detailed examples:
     parser.add_argument(
         "--languages",
         nargs="+",
-        choices=["python", "nodejs", "ruby", "go", "rust", "all"],
+        choices=[*SUPPORTED_LANGUAGES, "all"],
         default=["all"],
-        help="Languages to update (default: all)",
+        help="Languages to update (default: all supported languages)",
     )
     parser.add_argument(
         "--force", action="store_true", help="Force update even if cache is fresh"
@@ -737,7 +741,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     # Expand "all" to all supported languages
     if "all" in args.languages:
-        languages: List[str] = ["python", "nodejs", "ruby", "go", "rust"]
+        languages: List[str] = list(SUPPORTED_LANGUAGES)
     else:
         languages = args.languages
 

--- a/tests/features/test_version_cache.py
+++ b/tests/features/test_version_cache.py
@@ -10,7 +10,9 @@ import pytest
 from pytest_mock import MockFixture
 
 from json2vars_setter.features.version_cache import (
+    SUPPORTED_LANGUAGES,
     VersionCache,
+    build_parser,
     generate_version_template,
     main,
     update_versions,
@@ -22,6 +24,7 @@ from json2vars_setter.version.core.utils import (
     VersionInfo,
     get_utc_now,
 )
+from json2vars_setter.version.registry import LANGUAGE_FETCHERS
 
 # ---- Fixtures and Mocks ----
 
@@ -589,9 +592,9 @@ def test_main_function(mocker: MockFixture) -> None:
 
     main()
 
-    # update_versions should be called with all languages
+    # update_versions should be called with every supported language
     mock_update.assert_called_with(
-        ["python", "nodejs", "ruby", "go", "rust"],
+        list(SUPPORTED_LANGUAGES),
         force=True,
         max_age_days=1,
         count=10,
@@ -2166,3 +2169,18 @@ def test_generate_version_template_content_already_ends_with_newline(
     # Check that the file was written with the content exactly as returned by json.dumps
     # without adding an additional newline
     mock_open().write.assert_called_once_with('{"test": "value"}\n')
+
+
+def test_supported_languages_matches_registry() -> None:
+    """cache-version's language set must mirror the central registry (no drift)."""
+    assert SUPPORTED_LANGUAGES == list(LANGUAGE_FETCHERS)
+
+    parser = build_parser()
+    # Every registry language is selectable now, not just the original five.
+    for lang in LANGUAGE_FETCHERS:
+        assert parser.parse_args(["--languages", lang]).languages == [lang]
+    # "all" remains a valid meta-selector.
+    assert parser.parse_args(["--languages", "all"]).languages == ["all"]
+    # An unsupported language is rejected by argparse.
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--languages", "cobol"])


### PR DESCRIPTION
## Summary

`cache-version` (the version-cache feature) only accepted **5** languages
(`python, nodejs, ruby, go, rust`), while `update-matrix` and the fetcher
registry already support **18**. This derives the cache feature's language set
from the central registry so the two features stay in lock-step.

## Changes
- `features/version_cache.py`: add `SUPPORTED_LANGUAGES = list(LANGUAGE_FETCHERS)`
  and use it for both the `--languages` argparse `choices` and the `all`
  expansion. No more hardcoded 5-language lists — single source of truth.
- **Behavior change (intentional, confirmed):** `--languages all` is the default,
  and the action input `cache-languages` defaults to `all`. So `cache-version`
  with no `--languages`, and `use-cache: 'true'` without an explicit list, now
  cover **all 18** languages instead of five.
- Tests (100% coverage kept): the `all`-expansion assertion now references
  `SUPPORTED_LANGUAGES`, plus a new `test_supported_languages_matches_registry`
  guards registry parity and that every registry language is selectable.
- Docs: `docs/features/version-caching.md` lists all 18 languages.
- `CLAUDE.md`: the **Adding a New Language** checklist now records that the
  registry is the single source of truth and that `cache-version` derives its
  language set from it (never hardcode a list).

## Verification
- `pytest` full suite: **332 passed**, `version_cache.py` **100%** coverage.
- `mypy`, `ruff`, `ruff format`, pre-commit (incl. markdownlint, sync-doc-action-refs): all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)