### PR TITLE
:memo: Document bash & PowerShell tab completion for the json2vars CLI

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,6 +63,41 @@ Each line is one workflow output: the full JSON list (`VERSIONS_PYTHON`), each i
 !!! tip "Explore the other commands"
     Run `json2vars usage` for a task-oriented guide. Beyond `parse`, the CLI also exposes `update-matrix` (rewrite the matrix file with the latest/stable versions fetched from upstream) and `cache-version` (maintain a version cache) — the same engines behind the action's [dynamic update](features/dynamic-update.md) and [version caching](features/version-caching.md) features. Those two reach out to GitHub APIs, so set `GITHUB_TOKEN` to avoid rate limits.
 
+### Tab completion (bash & PowerShell)
+
+The CLI ships shell completion for the command names (`parse`, `update-matrix`,
+`cache-version`, `usage`). Install it once with the built-in command, which
+auto-detects your shell:
+
+```bash
+json2vars --install-completion
+```
+
+Then restart the shell. Typing `json2vars <TAB>` now lists the subcommands.
+
+To wire it up by hand (or inspect what gets installed), print the script with
+`json2vars --show-completion` and add it to your shell profile:
+
+=== "bash"
+
+    ```bash
+    # Append the generated script to your shell profile, then restart the shell
+    json2vars --show-completion >> ~/.bashrc
+    ```
+
+=== "PowerShell"
+
+    ```powershell
+    # Append the generated script to your $PROFILE, then restart the shell
+    json2vars --show-completion | Out-String | Add-Content $PROFILE
+    ```
+
+!!! note "Command names only"
+    Completion covers the **subcommand names**. Per-command options
+    (`--languages`, `--max-age`, `--cache-file`, …) are forwarded to each
+    feature's own parser, so they do **not** tab-complete — run
+    `json2vars <command> --help` (e.g. `json2vars cache-version --help`) to list them.
+
 ## Basic Setup
 
 ### Step 1: Create a JSON Configuration File

--- a/json2vars_setter/cli.py
+++ b/json2vars_setter/cli.py
@@ -129,6 +129,10 @@ def usage() -> None:
     typer.echo("See every option for a command:")
     typer.echo("  json2vars update-matrix --help")
     typer.echo("  json2vars cache-version --help")
+    typer.echo("")
+
+    typer.echo("Enable <Tab> completion of these command names (bash / PowerShell):")
+    typer.echo("  json2vars --install-completion")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,8 @@ def test_usage_command() -> None:
     assert "json2vars cache-version" in result.stdout
     assert "json2vars parse" in result.stdout
     assert "GITHUB_OUTPUT" in result.stdout
+    # Discoverability of shell completion (bash / PowerShell)
+    assert "json2vars --install-completion" in result.stdout
 
 
 def test_no_args_shows_help() -> None:


### PR DESCRIPTION
## Summary

`json2vars --help` already lists every command (including `cache-version`), and
the CLI ships shell completion via Typer/Click — but completion was **undocumented**,
so typing `json2vars <Tab>` did nothing and the commands looked "missing".

## Changes
- **getting-started.md**: new *Tab completion (bash & PowerShell)* section —
  `json2vars --install-completion` (auto-detects the shell) plus per-shell manual
  setup as content tabs (bash → `~/.bashrc`, PowerShell → `$PROFILE`), both via
  `--show-completion`. Content tabs render via `pymdownx.tabbed` (already enabled
  in `zensical.toml`).
- **Important caveat documented**: completion covers the **subcommand names**
  only. Per-command options (`--languages`, `--max-age`, …) are forwarded to each
  feature's own argparse parser, so they don't tab-complete — use
  `json2vars <command> --help`.
- **cli.py**: the `usage` command now surfaces `json2vars --install-completion`
  for discoverability (+ test assertion).

## Verification
- Confirmed the completion callback returns all 4 commands (incl. `cache-version`)
  in both bash and PowerShell.
- Full suite: **332 passed**, `cli.py` **100%** coverage. mypy / ruff / pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)