### PR TITLE
:memo: Robust PowerShell completer + command-execution tests

### DIFF
--- a/.issues/README.md
+++ b/.issues/README.md
@@ -1,0 +1,13 @@
+# `.issues/` — lightweight future-improvement backlog
+
+A visible, in-repo backlog of ideas that are **not worth a GitHub issue yet** but
+are worth keeping around because they could be **promoted to a real issue later**.
+
+- One Markdown file per idea.
+- **Naming:** `issue<N>-<type>-<slug>.md` (e.g. `issue1-enhancement-powershell-vertical-completion.md`).
+  `<N>` is a running number; `<type>` is a short label such as `enhancement`, `bug`,
+  `docs`, or `refactor`.
+- Capture enough context to act on it later (problem, findings, options, effort).
+- When an item is ready, open a GitHub issue / PR and remove (or link) the file.
+
+This is intentionally informal — it is a notepad, not a tracker.

--- a/.issues/issue1-enhancement-powershell-vertical-completion.md
+++ b/.issues/issue1-enhancement-powershell-vertical-completion.md
@@ -1,0 +1,40 @@
+# Vertical (arrow-navigable) completion candidate display in PowerShell
+
+**Status:** idea / future improvement — not scheduled.
+**Origin:** follow-up to the CLI shell-completion work (PR #552 option+value
+completion, PR #553 robust PowerShell completer in `scripts/json2vars-completion.ps1`).
+
+## What we'd want
+
+When completing `json2vars` in PowerShell, show the candidates as a **vertical list**
+(one per line) navigable with the ↑/↓ arrow keys, instead of the horizontal grid that
+PSReadLine's `MenuComplete` renders.
+
+## Findings (verified 2026-06)
+
+- PSReadLine's `MenuComplete` (bound to `Tab`) is a **horizontal grid**; the column
+  count is derived from the terminal width. **There is no PSReadLine option to force a
+  single-column / vertical layout.** The only menu-adjacent options are
+  `CompletionQueryItems` (threshold before "display all N?") and `PredictionViewStyle`.
+- Tested env: PowerShell 7.5.5, PSReadLine 2.3.6.
+
+## Options to get a vertical list
+
+| Approach | Vertical? | Shows our completer's candidates? | Effort | Notes |
+|---|---|---|---|---|
+| **PSFzf** (`Install-Module PSFzf` + `fzf`) | Yes (fzf list, with filtering) | Yes — hooks `Tab` and feeds existing completions to fzf | Low–Med | Applies shell-wide (git, docker, … all become vertical/fuzzy), not json2vars-only. Recommended if pursued. |
+| **`Out-ConsoleGridView`** (`Microsoft.PowerShell.ConsoleGuiTools`) + custom key handler | Yes (in-terminal grid) | Yes — handler collects completions and pipes to the picker | Med | Requires writing a `Set-PSReadLineKeyHandler` that gathers completions and inserts the selection. |
+| **PSReadLine ListView** (`-PredictionViewStyle ListView`) | Yes (vertical dropdown) | **No** — ListView is for *predictions* (history / predictor plugins), not Tab completion. Would need a custom `ICommandPredictor` plugin. | High | Not a fit for surfacing our argument completer. |
+
+## Trade-offs / why it's parked
+
+- The cleanest route (PSFzf) is a **shell-wide** UX change and an **extra dependency**
+  (`fzf` + `PSFzf`) the user must install — out of scope for a per-tool completer that
+  ships in this repo.
+- The current `scripts/json2vars-completion.ps1` already gives correct subcommand /
+  option / value completion; the horizontal grid is a cosmetic preference.
+
+## Promotion criteria
+
+Promote to a real issue/PR if we decide to **document an opt-in PSFzf recipe** in
+`docs/getting-started.md`, or if multiple users ask for vertical/fuzzy completion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,8 @@ A pluggable architecture for fetching language versions from GitHub:
 ### Entry Points
 
 - **GitHub Action**: `action.yml` defines the composite action with inputs/outputs; its steps invoke `python -m json2vars_setter.features.<module>`
-- **CLI**: `json2vars_setter/cli.py` — Typer app exposed as `json2vars` via `[project.scripts]`; commands call each feature's `main()` **in-process** (no subprocess). The three feature commands are **bridged** from each feature's `build_parser()`: `cli.py` generates the matching Click options dynamically (argparse stays the single source of truth) so shell completion covers the per-command options/values, then reconstructs argv and calls `main()`. A new feature option therefore needs **no** cli.py change. One consequence: the repeated argparse option `--languages` is completed one value at a time, so via the `json2vars` script you repeat the flag (`--languages python --languages nodejs`); `python -m …` still takes the space-separated list.
+- **CLI**: `json2vars_setter/cli.py` — Typer app exposed as `json2vars` via `[project.scripts]`; commands call each feature's `main()` **in-process** (no subprocess). The three feature commands are **bridged** from each feature's `build_parser()`: `cli.py` generates the matching options dynamically (argparse stays the single source of truth) so shell completion covers the per-command options **and values**, then reconstructs argv and calls `main()`. A new feature option therefore needs **no** cli.py change. **The bridged params must be built as `typer.core.TyperOption` (not plain `click.Option`)**: Typer's completer only resolves an option's *value* when the param is a `TyperOption`, and choice values are supplied via the public `shell_complete=` callback — a plain `click.Option` completes option *names* but silently drops value completion. One consequence: the repeated argparse option `--languages` is completed one value at a time, so via the `json2vars` script you repeat the flag (`--languages python --languages nodejs`); `python -m …` still takes the space-separated list.
+- **Shell completion**: bash uses Typer's generated completer as-is (its output is plain values — robust). **PowerShell** ships a hand-written completer at `scripts/json2vars-completion.ps1` (dot-source it from `$PROFILE`; documented in `docs/getting-started.md`) — Typer's generated PowerShell completer splits each `value:::help` line on `:::` and builds a `CompletionResult` whose tooltip must be non-empty, so **long help that wraps across lines throws and a whole command returns zero completions while leaking the completion env vars** (a later `--help` then prints completion noise). The shipped completer keeps only `:::` lines, splits on the first separator, falls back to the value for an empty tooltip, resets env vars in `finally`, and surfaces options at the bare command position. **Command-execution (subprocess) tests** for this live in `tests/test_cli_exec.py`, separate from the in-process `tests/test_cli.py`.
 - **Direct module execution**: `python -m json2vars_setter.features.<module>`
 
 ## Adding a New Language (complete checklist)
@@ -221,3 +222,13 @@ Releases are **manually triggered** (`workflow_dispatch` on `semantic-release.ym
 - Cache file: `.github/json2vars-setter/cache/version_cache.json`
 - Test fixtures: `tests/matrix_static.json`, `tests/python_project_matrix.json`
 - Docs site: `docs/` (MkDocs Material, deployed to GitHub Pages)
+- PowerShell completion script: `scripts/json2vars-completion.ps1`
+- Future-improvement backlog: `.issues/`
+
+## Future-Improvement Backlog (`.issues/`)
+
+`.issues/` is a **lightweight, in-repo backlog** of ideas that are **not worth a
+GitHub issue yet** but could be **promoted to one later** (kept visible in the repo
+rather than lost in chat). It is a notepad, not a tracker. One Markdown file per idea,
+named `issue<N>-<type>-<slug>.md` (`<type>` ∈ `enhancement`/`bug`/`docs`/`refactor`),
+each capturing the problem, findings, options, and effort. See `.issues/README.md`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,9 +69,10 @@ The CLI ships shell completion for the commands (`parse`, `update-matrix`,
 `cache-version`, `usage`), **their options, and option values**:
 
 - `json2vars <TAB>` → the subcommands
-- `json2vars cache-version -<TAB>` → that command's options (`--languages`,
-  `--max-age`, …). Type a leading `-` first — option names only complete once the
-  current word starts with a dash (standard Click/Typer behaviour).
+- `json2vars cache-version <TAB>` → that command's options (`--languages`,
+  `--max-age`, …). With the PowerShell block below they appear at the bare command
+  position; in bash, type a leading `-` first (`cache-version -<TAB>`), since
+  Click only completes option names once the word starts with a dash.
 - `json2vars cache-version --languages <TAB>` → the supported languages;
   `json2vars update-matrix --python <TAB>` → `stable/latest/both`
 
@@ -98,24 +99,39 @@ restart the shell:
 ```powershell
 $json2varsCompleter = {
     param($wordToComplete, $commandAst, $cursorPosition)
-    $Env:_JSON2VARS_COMPLETE = "complete_powershell"
-    $Env:_TYPER_COMPLETE_ARGS = $commandAst.ToString()
-    $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = $wordToComplete
-    try {
-        json2vars | Where-Object { $_ -like '*:::*' } | ForEach-Object {
-            $i = $_.IndexOf(':::')
-            $value = $_.Substring(0, $i)
-            if ([string]::IsNullOrWhiteSpace($value)) { return }
-            $help = $_.Substring($i + 3).Trim()
-            if ([string]::IsNullOrWhiteSpace($help)) { $help = $value }
-            [System.Management.Automation.CompletionResult]::new(
-                $value, $value, 'ParameterValue', $help)
+    $base = $commandAst.ToString()
+    $seen = @{}
+    $results = [System.Collections.Generic.List[System.Management.Automation.CompletionResult]]::new()
+    $fetch = {
+        param($a, $w)
+        $Env:_JSON2VARS_COMPLETE = "complete_powershell"
+        $Env:_TYPER_COMPLETE_ARGS = $a
+        $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = $w
+        try {
+            json2vars | Where-Object { $_ -like '*:::*' } | ForEach-Object {
+                $i = $_.IndexOf(':::')
+                $v = $_.Substring(0, $i)
+                if ([string]::IsNullOrWhiteSpace($v) -or $seen.ContainsKey($v)) { return }
+                $seen[$v] = $true
+                $h = $_.Substring($i + 3).Trim()
+                if ([string]::IsNullOrWhiteSpace($h)) { $h = $v }
+                $results.Add([System.Management.Automation.CompletionResult]::new(
+                        $v, $v, 'ParameterValue', $h))
+            }
         }
-    } finally {
-        $Env:_JSON2VARS_COMPLETE = ""
-        $Env:_TYPER_COMPLETE_ARGS = ""
-        $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = ""
+        finally {
+            $Env:_JSON2VARS_COMPLETE = ""
+            $Env:_TYPER_COMPLETE_ARGS = ""
+            $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = ""
+        }
     }
+    & $fetch $base $wordToComplete
+    # Nothing matched at an empty word (an option position, no dash typed): offer
+    # the command's option names so they are discoverable without a leading '-'.
+    if ($results.Count -eq 0 -and [string]::IsNullOrEmpty($wordToComplete)) {
+        & $fetch ($base.TrimEnd() + ' -') '-'
+    }
+    $results
 }
 Register-ArgumentCompleter -Native -CommandName json2vars -ScriptBlock $json2varsCompleter
 ```
@@ -125,10 +141,12 @@ Register-ArgumentCompleter -Native -CommandName json2vars -ScriptBlock $json2var
     builds a `CompletionResult` whose tooltip must be non-empty. When an option's
     help is long, Typer wraps it across lines; the wrapped fragment has no `:::`,
     so the tooltip is empty and `CompletionResult` **throws** — making a whole
-    command (e.g. `cache-version`) return *no* completions, and leaking the
-    completion env vars to boot. The block above keeps only lines containing
+    command (e.g. `cache-version`) return *no* completions, and **leaking the
+    completion env vars** (after which a normal `json2vars … --help` prints
+    completion noise instead of help). The block above keeps only lines containing
     `:::`, splits on the first one, falls back to the value for an empty tooltip,
-    and resets the env vars in `finally`, so it stays robust.
+    resets the env vars in `finally`, and (only when a bare word matched nothing)
+    re-queries to surface the option names — so it stays robust *and* discoverable.
 
 !!! tip "Seeing the candidate menu (PowerShell)"
     PowerShell's default `Tab` inserts the first match and cycles one at a time.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,35 +66,75 @@ Each line is one workflow output: the full JSON list (`VERSIONS_PYTHON`), each i
 ### Tab completion (bash & PowerShell)
 
 The CLI ships shell completion for the commands (`parse`, `update-matrix`,
-`cache-version`, `usage`) **and their options** — `json2vars cache-version --<TAB>`
-lists `--languages`, `--max-age`, …, and value completion works too
-(`--languages <TAB>` → the supported languages, `--python <TAB>` →
-`stable/latest/both`). Install it once with the built-in command, which
-auto-detects your shell:
+`cache-version`, `usage`), **their options, and option values**:
+
+- `json2vars <TAB>` → the subcommands
+- `json2vars cache-version -<TAB>` → that command's options (`--languages`,
+  `--max-age`, …). Type a leading `-` first — option names only complete once the
+  current word starts with a dash (standard Click/Typer behaviour).
+- `json2vars cache-version --languages <TAB>` → the supported languages;
+  `json2vars update-matrix --python <TAB>` → `stable/latest/both`
+
+#### bash
+
+Install once with the built-in command (it auto-detects your shell), then restart
+the shell:
 
 ```bash
 json2vars --install-completion
 ```
 
-Then restart the shell. Typing `json2vars <TAB>` now lists the subcommands, and
-each subcommand completes its own options.
+Or wire it up by hand:
 
-To wire it up by hand (or inspect what gets installed), print the script with
-`json2vars --show-completion` and add it to your shell profile:
+```bash
+json2vars --show-completion >> ~/.bashrc
+```
 
-=== "bash"
+#### PowerShell
 
-    ```bash
-    # Append the generated script to your shell profile, then restart the shell
-    json2vars --show-completion >> ~/.bashrc
-    ```
+Add the block below to your `$PROFILE` (open it with `notepad $PROFILE`), then
+restart the shell:
 
-=== "PowerShell"
+```powershell
+$json2varsCompleter = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    $Env:_JSON2VARS_COMPLETE = "complete_powershell"
+    $Env:_TYPER_COMPLETE_ARGS = $commandAst.ToString()
+    $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = $wordToComplete
+    try {
+        json2vars | Where-Object { $_ -like '*:::*' } | ForEach-Object {
+            $i = $_.IndexOf(':::')
+            $value = $_.Substring(0, $i)
+            if ([string]::IsNullOrWhiteSpace($value)) { return }
+            $help = $_.Substring($i + 3).Trim()
+            if ([string]::IsNullOrWhiteSpace($help)) { $help = $value }
+            [System.Management.Automation.CompletionResult]::new(
+                $value, $value, 'ParameterValue', $help)
+        }
+    } finally {
+        $Env:_JSON2VARS_COMPLETE = ""
+        $Env:_TYPER_COMPLETE_ARGS = ""
+        $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = ""
+    }
+}
+Register-ArgumentCompleter -Native -CommandName json2vars -ScriptBlock $json2varsCompleter
+```
 
-    ```powershell
-    # Append the generated script to your $PROFILE, then restart the shell
-    json2vars --show-completion | Out-String | Add-Content $PROFILE
-    ```
+!!! note "Why not `json2vars --show-completion` on PowerShell?"
+    Typer's generated PowerShell completer splits each candidate on `:::` and
+    builds a `CompletionResult` whose tooltip must be non-empty. When an option's
+    help is long, Typer wraps it across lines; the wrapped fragment has no `:::`,
+    so the tooltip is empty and `CompletionResult` **throws** — making a whole
+    command (e.g. `cache-version`) return *no* completions, and leaking the
+    completion env vars to boot. The block above keeps only lines containing
+    `:::`, splits on the first one, falls back to the value for an empty tooltip,
+    and resets the env vars in `finally`, so it stays robust.
+
+!!! tip "Seeing the candidate menu (PowerShell)"
+    PowerShell's default `Tab` inserts the first match and cycles one at a time.
+    To pop up a **navigable menu** and pick with the arrow keys, press
+    **Ctrl+Space** (PSReadLine's built-in `MenuComplete`) — no keybinding change
+    needed, so your existing key setup is left untouched.
 
 !!! note "Multi-value `--languages`"
     Because options are completed one value at a time, pass several languages by

--- a/scripts/json2vars-completion.ps1
+++ b/scripts/json2vars-completion.ps1
@@ -1,0 +1,53 @@
+# json2vars PowerShell tab completion (robust + discoverable).
+#
+# Dot-source this from your $PROFILE:
+#     . "<path-to-repo>\scripts\json2vars-completion.ps1"
+#
+# Why not `json2vars --show-completion`? Typer's generated completer splits each
+# `value:::help` candidate on ":::" and builds a CompletionResult whose tooltip
+# must be non-empty. Long option help is wrapped across lines by Typer/rich; the
+# wrapped fragment has no ":::", so the tooltip is empty and CompletionResult
+# throws -- a whole command (e.g. cache-version) then returns no completions and
+# the completion env vars leak (a later `json2vars --help` prints completion noise
+# instead of help). This completer keeps only ":::" lines, splits on the first
+# separator, falls back to the value for an empty tooltip, resets the env vars in
+# finally, and -- only when a bare word matched nothing -- re-queries so option
+# names are discoverable without typing a leading dash.
+
+$json2varsCompleter = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    $base = $commandAst.ToString()
+    $seen = @{}
+    $results = [System.Collections.Generic.List[System.Management.Automation.CompletionResult]]::new()
+    $fetch = {
+        param($a, $w)
+        $Env:_JSON2VARS_COMPLETE = "complete_powershell"
+        $Env:_TYPER_COMPLETE_ARGS = $a
+        $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = $w
+        try {
+            json2vars | Where-Object { $_ -like '*:::*' } | ForEach-Object {
+                $i = $_.IndexOf(':::')
+                $v = $_.Substring(0, $i)
+                if ([string]::IsNullOrWhiteSpace($v) -or $seen.ContainsKey($v)) { return }
+                $seen[$v] = $true
+                $h = $_.Substring($i + 3).Trim()
+                if ([string]::IsNullOrWhiteSpace($h)) { $h = $v }
+                $results.Add([System.Management.Automation.CompletionResult]::new(
+                        $v, $v, 'ParameterValue', $h))
+            }
+        }
+        finally {
+            $Env:_JSON2VARS_COMPLETE = ""
+            $Env:_TYPER_COMPLETE_ARGS = ""
+            $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = ""
+        }
+    }
+    & $fetch $base $wordToComplete
+    # Nothing matched at an empty word (an option position, no dash typed): offer
+    # the command's option names so they are discoverable without a leading '-'.
+    if ($results.Count -eq 0 -and [string]::IsNullOrEmpty($wordToComplete)) {
+        & $fetch ($base.TrimEnd() + ' -') '-'
+    }
+    $results
+}
+Register-ArgumentCompleter -Native -CommandName json2vars -ScriptBlock $json2varsCompleter

--- a/tests/test_cli_exec.py
+++ b/tests/test_cli_exec.py
@@ -1,0 +1,190 @@
+"""
+Command-execution tests for the ``json2vars`` console script.
+
+Unlike ``tests/test_cli.py`` (in-process, ``CliRunner`` + mocked feature ``main``),
+these run the **installed console script as a real subprocess** — the same path a
+shell takes. They guard two things the unit tests cannot see:
+
+1. End-to-end execution: ``json2vars parse`` actually writes ``GITHUB_OUTPUT``.
+2. Shell-completion robustness: the ``complete_powershell`` protocol output stays
+   parseable by the documented PowerShell completer even when an option's help is
+   long enough that Typer wraps it across lines.
+
+The regression this locks in: ``cache-version`` has long option help (``--output-count``,
+``--cache-file``, …). Typer wraps it to ~80 cols when stdout is a pipe; the wrapped
+fragment has no ``:::`` separator. A naive ``$_ -split ':::'`` PowerShell completer then
+builds a ``CompletionResult`` with an empty tooltip, which throws and makes the *whole*
+command return zero completions. The documented robust completer (and ``_robust_parse``
+below, which mirrors it) keeps only ``:::`` lines and splits on the first separator.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+from json2vars_setter.features import matrix_update, version_cache
+
+
+def _console_script() -> Optional[Path]:
+    """Locate the installed ``json2vars`` entry point for this interpreter."""
+    scripts_dir = Path(sys.executable).parent
+    for name in ("json2vars.exe", "json2vars"):
+        candidate = scripts_dir / name
+        if candidate.exists():
+            return candidate
+    found = shutil.which("json2vars")
+    return Path(found) if found else None
+
+
+_JSON2VARS = _console_script()
+requires_script = pytest.mark.skipif(
+    _JSON2VARS is None, reason="json2vars console script is not installed"
+)
+
+
+def _long_opts(parser: "object") -> set[str]:
+    """Long (``--``) option strings declared by an argparse parser."""
+    actions = parser._actions  # type: ignore[attr-defined]
+    return {
+        opt
+        for action in actions
+        for opt in action.option_strings
+        if opt.startswith("--")
+    }
+
+
+def _robust_parse(raw: str) -> List[str]:
+    """Parse ``value:::help`` completion output the way the docs' PowerShell
+    completer does: keep only lines that contain ``:::`` (dropping wrapped help
+    fragments) and split on the **first** separator."""
+    values: List[str] = []
+    for line in raw.splitlines():
+        if ":::" not in line:
+            continue
+        value = line.split(":::", 1)[0]
+        if value.strip():
+            values.append(value)
+    return values
+
+
+def _complete(args: str, word: str = "", columns: str = "20") -> str:
+    """Run the console script under the PowerShell completion protocol.
+
+    ``columns`` is forced small so Typer/rich wraps long help across lines —
+    reproducing the condition that broke the naive completer.
+    """
+    assert _JSON2VARS is not None
+    env = {
+        **os.environ,
+        "_JSON2VARS_COMPLETE": "complete_powershell",
+        "_TYPER_COMPLETE_ARGS": args,
+        "_TYPER_COMPLETE_WORD_TO_COMPLETE": word,
+        "COLUMNS": columns,
+    }
+    result = subprocess.run(
+        [str(_JSON2VARS)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return result.stdout
+
+
+@requires_script
+def test_parse_writes_github_output(tmp_path: Path) -> None:
+    """`json2vars parse` expands a JSON file into the GITHUB_OUTPUT file."""
+    matrix = tmp_path / "matrix.json"
+    matrix.write_text(
+        '{"os": ["ubuntu-latest"], "versions": {"python": ["3.12"]}, '
+        '"ghpages_branch": "gh-pages"}',
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.txt"
+    env = {**os.environ, "GITHUB_OUTPUT": str(out)}
+
+    result = subprocess.run(
+        [str(_JSON2VARS), "parse", str(matrix)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+    content = out.read_text(encoding="utf-8")
+    assert 'OS=["ubuntu-latest"]' in content
+    assert 'VERSIONS_PYTHON=["3.12"]' in content
+    assert "GHPAGES_BRANCH=gh-pages" in content
+
+
+@requires_script
+def test_completion_lists_subcommands() -> None:
+    """`json2vars <TAB>` completes the four subcommands."""
+    values = _robust_parse(_complete("json2vars "))
+    assert {"usage", "update-matrix", "cache-version", "parse"} <= set(values)
+
+
+@requires_script
+@pytest.mark.parametrize("command", ["cache-version", "update-matrix"])
+def test_completion_options_survive_wrapped_help(command: str) -> None:
+    """`json2vars <command> -<TAB>` recovers every long option even when help wraps.
+
+    With COLUMNS forced small, ``cache-version``'s long-help options wrap — the
+    exact case that made the naive completer return nothing. Robust parsing must
+    still recover the full option set declared by the argparse parser.
+    """
+    parser = (
+        version_cache.build_parser()
+        if command == "cache-version"
+        else matrix_update.build_parser()
+    )
+    expected = _long_opts(parser)
+
+    recovered = set(_robust_parse(_complete(f"json2vars {command} -", word="-")))
+
+    missing = expected - recovered
+    assert not missing, f"{command}: completion dropped {sorted(missing)}"
+
+
+@requires_script
+def test_completion_values_languages_and_strategy() -> None:
+    """Value completion works through the real process for choices."""
+    langs = _robust_parse(_complete("json2vars cache-version --languages "))
+    assert "python" in langs
+    assert "all" in langs
+
+    strategies = _robust_parse(_complete("json2vars update-matrix --python "))
+    assert set(strategies) == {"stable", "latest", "both"}
+
+
+def test_robust_parse_recovers_value_from_wrapped_help() -> None:
+    """The robust parser tolerates wrapped help (the documented PowerShell logic).
+
+    A naive ``split(':::')[0]`` would treat the wrapped continuation line as a
+    bogus completion value; the robust parser drops lines without a separator.
+    This is deterministic and needs no subprocess.
+    """
+    wrapped = (
+        "--output-count:::Number of versions to include in output template "
+        "(default: 0, uses count value\n"
+        "if not specified)\n"
+        "--cache-file:::Custom cache file path (default:\n"
+        ".github\\json2vars-setter\\cache\\version_cache.json)\n"
+        "--help:::Show this message and exit.\n"
+    )
+
+    values = _robust_parse(wrapped)
+
+    assert values == ["--output-count", "--cache-file", "--help"]
+    # The wrapped continuation lines must not leak in as bogus candidates.
+    assert "if not specified)" not in values
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

Fixes PowerShell tab completion silently returning **zero** candidates for
commands with long option help (most visibly `cache-version`), and adds a
subprocess **command-execution** test suite that guards this class of bug.

## Root cause

Typer's generated PowerShell completer parses each `value:::help` line by
splitting on `:::` and building a `CompletionResult` whose tooltip must be
non-empty. When an option's help is long, Typer/rich wraps it to ~80 cols on a
pipe; the **wrapped fragment has no `:::`**, so its tooltip is empty and
`CompletionResult` **throws** — aborting the whole completer (no candidates) and
leaking the `_JSON2VARS_COMPLETE` / `_TYPER_COMPLETE_*` env vars. `update-matrix`
(short help) was unaffected, which is exactly why it looked inconsistent
(`update-matrix -<TAB>` → 24 options, `cache-version -<TAB>` → nothing).

The Python completion engine itself is correct (it emits all 16 options); the
breakage is purely in the fragile shell-side parsing.

## What changed

- **docs/getting-started.md** — replace the fragile `json2vars --show-completion`
  PowerShell recipe with a **robust completer**: keep only lines containing `:::`,
  split on the **first** separator, fall back to the value for an empty tooltip,
  and reset the env vars in `finally`. Also document that option names need a
  leading `-`, and that **Ctrl+Space** (PSReadLine `MenuComplete`) pops the
  navigable menu without remapping `Tab` (keybinding-neutral).
- **tests/test_cli_exec.py** (new) — command-execution tests that run the real
  installed console script as a subprocess:
  - `parse` → writes `GITHUB_OUTPUT` end-to-end.
  - `complete_powershell` protocol for subcommands / options / values.
  - **Regression guard**: forces `COLUMNS` small so `cache-version` help wraps,
    then asserts the robust parse recovers **every** long option from the argparse
    parser (the source of truth). Parametrized over `cache-version` + `update-matrix`.
  - A deterministic `_robust_parse` unit proving wrapped continuation lines never
    leak in as bogus candidates (no subprocess needed).

## Verification

- `pytest --cov`: **343 passed**, package coverage **100%**.
- `mypy`, `ruff`, `ruff format`, pre-commit (markdownlint, sync-doc-action-refs): pass.
- No package code changed (the fix is the documented completer + tests), so this is
  `:memo:` and triggers **no release**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)