### PR TITLE
:green_heart: Make the badge-update step non-fatal (transient gist-API failures)

### DIFF
--- a/.github/workflows/bun_test.yml
+++ b/.github/workflows/bun_test.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 431a19225ef80b473e7eee8e060b7516

--- a/.github/workflows/crystal_test.yml
+++ b/.github/workflows/crystal_test.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 09c90cf4e8e97865f6213085c82716e4

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -149,6 +149,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 838b360075fcd8c54f8ccdb2a8ff2e88

--- a/.github/workflows/deno_test.yml
+++ b/.github/workflows/deno_test.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 5a34d5cdfb2b13ed4ab1939009b6f5b1

--- a/.github/workflows/dotnet_test.yml
+++ b/.github/workflows/dotnet_test.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 33c8a05d3ed6c038877d847ffc12b2f9

--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -148,6 +148,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: b93c2abf130e91304761df9da4bb5533

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -172,6 +172,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: c334da204406866563668140885d170e

--- a/.github/workflows/haskell_test.yml
+++ b/.github/workflows/haskell_test.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: ac694a2ecdc91ee32dda6afa49863aa4

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -151,6 +151,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 813e5201a834d06253014b66ee8fd154

--- a/.github/workflows/julia_test.yml
+++ b/.github/workflows/julia_test.yml
@@ -149,6 +149,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 2d784d1513f73b0cd94f974742f33340

--- a/.github/workflows/nodejs_test.yml
+++ b/.github/workflows/nodejs_test.yml
@@ -159,6 +159,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 11f46ff9ef47d3362dabe767255b0d9e

--- a/.github/workflows/ocaml_test.yml
+++ b/.github/workflows/ocaml_test.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: ac8d039239f77264250f852a38143043

--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -151,6 +151,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: a9bc428c9f5a2f998bd7307038e557e1

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -155,6 +155,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 26cb492ab0cfff920c516a622b2bfa44

--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -161,6 +161,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 511ba5b5711e66c507292ba00cf0a219

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -180,6 +180,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 5e160d06cfffd42a8f0e4ae6e8e8f025

--- a/.github/workflows/sample_conditional_matrix.yml
+++ b/.github/workflows/sample_conditional_matrix.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: d3189e6457c55fb9ee6859b4809be195

--- a/.github/workflows/sample_dynamic_update.yml
+++ b/.github/workflows/sample_dynamic_update.yml
@@ -85,6 +85,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: d6a3df65bb1dbd6eebf6ca7bdd938d80

--- a/.github/workflows/sample_monorepo.yml
+++ b/.github/workflows/sample_monorepo.yml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: f656174a6e80a09b405b7998acadfbbc

--- a/.github/workflows/sample_reusable_workflow.yml
+++ b/.github/workflows/sample_reusable_workflow.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 16a9385abb96e85e10de11afab646f8f

--- a/.github/workflows/sample_single_source.yml
+++ b/.github/workflows/sample_single_source.yml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 43c16c21c735a80b673a65e1bb0d9619

--- a/.github/workflows/sample_template.yml
+++ b/.github/workflows/sample_template.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 0d505761860b197c29ff8b6ec3c3a0ed

--- a/.github/workflows/sample_version_cache.yml
+++ b/.github/workflows/sample_version_cache.yml
@@ -102,6 +102,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: f6745f3939de53fca5fa14ed4030752d

--- a/.github/workflows/swift_test.yml
+++ b/.github/workflows/swift_test.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: c20279820e1c89d7864bf440e8c7cfa2

--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Create badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        continue-on-error: true
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: 35f4914a9b707f6570a2c7b508e1f675


### PR DESCRIPTION
## Summary

A scheduled run of **Sample - Dynamic Update** failed with `TypeError: fetch failed`
in the `schneegans/dynamic-badges-action` **Create badge** step — a **transient
GitHub gist-API network error**, not a config/code bug:

- The same step **succeeds on `pull_request` runs** under the identical
  `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env.
- **Re-running the failed job passed** (run 27136706212).

The badge update is purely cosmetic (writes a shields.io endpoint gist), so a flaky
gist call should not turn a whole test/sample run red.

## Change

Add `continue-on-error: true` to the **Create badge** step in **all 25 workflows**
that use `dynamic-badges-action` — the per-language `*_test.yml` and the
`sample_*.yml` gallery. A transient failure now leaves the run green; the badge
simply refreshes on the next scheduled/push run.

## Notes

- CI-only change; commit uses `:green_heart:`, which is **not** in the
  `.releaserc.json` patch rules, so **no release is triggered**.
- Validated with actionlint + `check yaml` (pre-commit) across all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)