### PR TITLE
:wrench: Enable ruff flake8-bandit (S) SAST rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,17 @@ exclude = [
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "B", "ANN", "RUF"]
+# S = flake8-bandit (SAST): flags shell=True, eval, unsafe yaml.load, requests
+# without timeout, etc. The shipped package (json2vars_setter) is clean today;
+# the rule keeps it that way.
+select = ["E", "F", "I", "B", "ANN", "RUF", "S"]
 # ANN401 (ban typing.Any in annotations) is intentionally kept on to enforce the
 # project-wide "no Any" rule, alongside mypy's disallow_any_explicit.
 ignore = ["E402", "E501"]
-per-file-ignores = {}
+# Bandit rules that are legitimate in the test suite, not production code:
+# S101 assert (pytest), S603/S607 subprocess (command-execution tests), and
+# S105 a fake "test-token" fixture string.
+per-file-ignores = { "tests/**" = ["S101", "S105", "S603", "S607"] }
 
 [tool.typos.files]
 extend-exclude = [


### PR DESCRIPTION
## Summary

Adds the `S` (flake8-bandit) ruleset to ruff so SAST runs as part of the linter
that already executes in pre-commit and CI — **no new tool or dependency**. This
captures the intent of a Semgrep-style SAST step (catch `shell=True`, `eval`,
unsafe `yaml.load`, `requests` without timeout, etc.) but integrated into the
existing toolchain.

## Why this over Semgrep

The shipped package has **no** shell/`subprocess`/`eval`/SQL/`pickle`/`yaml.load`
usage, so `ruff --select S` on `json2vars_setter/` reports **0 findings** today.
Enabling `S` is a zero-cost guardrail that keeps it that way (relevant for
AI-assisted contributions), without the registry dependency and extra CI step a
separate Semgrep job would add.

## Changes

- `pyproject.toml`: `select` gains `"S"`.
- `per-file-ignores` for `tests/**`: `S101` (pytest `assert`), `S603`/`S607` (the
  command-execution subprocess tests in `tests/test_cli_exec.py`), `S105` (a fake
  `"test-token"` fixture string in `tests/version/core/test_base.py` — verified
  not a real secret).

## Verification

- `ruff check json2vars_setter tests` (with `S`): **All checks passed**.
- `ruff format --check`, `validate-pyproject`, full suite **343 passed**.

Complements the repo's existing security tooling (gitleaks, zizmor, pip-audit,
SHA-pinned actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)