### PR TITLE
:lock: Declare explicit least-privilege permissions (contents: read) on all workflows

### DIFF
--- a/.github/workflows/bun_test.yml
+++ b/.github/workflows/bun_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/crystal_test.yml
+++ b/.github/workflows/crystal_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/deno_test.yml
+++ b/.github/workflows/deno_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet_test.yml
+++ b/.github/workflows/dotnet_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -15,6 +15,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/haskell_test.yml
+++ b/.github/workflows/haskell_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/julia_test.yml
+++ b/.github/workflows/julia_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs_test.yml
+++ b/.github/workflows/nodejs_test.yml
@@ -15,6 +15,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/ocaml_test.yml
+++ b/.github/workflows/ocaml_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -17,6 +17,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -15,6 +15,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/sample_conditional_matrix.yml
+++ b/.github/workflows/sample_conditional_matrix.yml
@@ -21,6 +21,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/sample_dynamic_update.yml
+++ b/.github/workflows/sample_dynamic_update.yml
@@ -29,6 +29,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/sample_monorepo.yml
+++ b/.github/workflows/sample_monorepo.yml
@@ -24,6 +24,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   # --- Backend project: its own JSON -> its own Python matrix ---------------
   backend_vars:

--- a/.github/workflows/sample_reusable_lib.yml
+++ b/.github/workflows/sample_reusable_lib.yml
@@ -27,6 +27,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   vars:
     runs-on: ubuntu-latest

--- a/.github/workflows/sample_reusable_workflow.yml
+++ b/.github/workflows/sample_reusable_workflow.yml
@@ -23,6 +23,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   # Call the reusable library to produce the matrix outputs.
   vars:

--- a/.github/workflows/sample_single_source.yml
+++ b/.github/workflows/sample_single_source.yml
@@ -30,6 +30,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   # Step 1: read the matrix from the single JSON file and expose it as outputs.
   set_variables:

--- a/.github/workflows/sample_template.yml
+++ b/.github/workflows/sample_template.yml
@@ -25,6 +25,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/sample_version_cache.yml
+++ b/.github/workflows/sample_version_cache.yml
@@ -23,6 +23,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/swift_test.yml
+++ b/.github/workflows/swift_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-requirements-after-dependabot.yml
+++ b/.github/workflows/update-requirements-after-dependabot.yml
@@ -15,6 +15,9 @@ on:
     types: [closed]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-requirements:
     if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/update_pre-commit_hooks.yml
+++ b/.github/workflows/update_pre-commit_hooks.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * 5'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -14,6 +14,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   set_variables:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a top-level `permissions: contents: read` to the **28 workflows** that
previously relied on the repo-default token scope. Now every workflow states its
GITHUB_TOKEN least-privilege explicitly (the 7 that need more — Pages deploy,
semantic-release, dependabot helpers — already declared theirs).

## Defense-in-depth, not a fix

The repo default is already `default_workflow_permissions: read`, so **effective
behavior is unchanged**. Declaring it explicitly:

- documents intent per workflow,
- survives a future change to the repo-level default,
- clears zizmor's `token-permissions` warnings.

## Safety

Verified safe for every job:
- The per-language `*_test.yml` and `sample_*.yml` only **read** (checkout +
  GitHub API version fetches); the `update_badge` steps write via the
  **`GIST_TOKEN` PAT**, not GITHUB_TOKEN.
- `update_pre-commit_hooks.yml` / `update-requirements-after-dependabot.yml` push
  via the **`PAT_FOR_PUSHES` PAT**, not GITHUB_TOKEN.
- `sample_reusable_lib.yml` (`workflow_call`) is read-only.
- No `pull_request_target`; all third-party actions remain SHA-pinned.

## Verification

- Clean diff: 28 files, **84 insertions** (exactly the 3-line block each).
- pre-commit: actionlint, check-yaml, mixed-line-ending — all pass.

Context: this is the GITHUB_TOKEN-least-privilege takeaway from the supply-chain
security discussion. The observability tooling from that article (eBPF agents,
self-hosted runners, registry proxies) is intentionally out of scope for this
project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)