### PR TITLE
:wrench: Add Dependabot coverage for php/dotnet/java/dart/swift examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ version: 2
 # Update policy
 # - The shipped Python package (pip) and GitHub Actions are updated daily,
 #   including major versions, so the action itself stays current and secure.
-# - The language examples (npm / bundler / gomod / cargo) are demos. They are
+# - The language examples (npm / bundler / gomod / cargo / composer / nuget /
+#   maven / pub / swift) are demos. They are
 #   updated weekly and **major-version bumps are ignored**, because a major bump
 #   can raise a dependency's required language runtime above what the example
 #   test matrix covers (e.g. parallel 1.x -> 2.1.0 requiring Ruby >= 3.3; see
@@ -66,6 +67,76 @@ updates:
   # Rust dependencies (example)
   - package-ecosystem: "cargo"
     directory: "/examples/rust"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+
+  # PHP dependencies (example)
+  - package-ecosystem: "composer"
+    directory: "/examples/php"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+
+  # .NET (C#) dependencies (example)
+  - package-ecosystem: "nuget"
+    directory: "/examples/dotnet"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+
+  # Java dependencies (example)
+  - package-ecosystem: "maven"
+    directory: "/examples/java"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+
+  # Dart dependencies (example)
+  - package-ecosystem: "pub"
+    directory: "/examples/dart"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+
+  # Swift dependencies (example)
+  - package-ecosystem: "swift"
+    directory: "/examples/swift"
     schedule:
       interval: "weekly"
     groups:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,15 @@ or the addition is incomplete:
 6. **Example project** — `examples/<lang>/`: a small JSON-parser project with source,
    tests, `<lang>_project_matrix.json`, build config, and `README.md` (mirror
    `examples/ruby/`). The matrix versions must be in the format the language's
-   `setup-*` action accepts.
+   `setup-*` action accepts. **Also decide on Dependabot coverage**: if the example
+   ships a dependency manifest that Dependabot supports (e.g. `composer.json`→`composer`,
+   `*.csproj`→`nuget`, `pom.xml`→`maven`, `pubspec.yaml`→`pub`, `Package.swift`→`swift`,
+   `go.mod`→`gomod`, `Cargo.toml`→`cargo`, `package.json`→`npm`, `Gemfile`→`bundler`), add a
+   matching `package-ecosystem` block in `.github/dependabot.yml` mirroring the existing
+   example entries (weekly, grouped `*`, **major-version bumps ignored**, limit 10).
+   Languages whose manifest Dependabot does **not** support — crystal (shards), haskell
+   (cabal), julia (Pkg), ocaml (opam), deno, zig — get **no** entry; note that in the PR so
+   the omission is intentional, not drift.
 7. **Example CI workflow** — `.github/workflows/<lang>_test.yml` (mirror
    `ruby_test.yml`): `set_variables` → `run_tests` (matrix) → `update_badge`. The
    `update_badge` job needs a **dedicated gist** (`<lang>-test-badge.json`, written via


### PR DESCRIPTION
## Summary

Five example projects ship a dependency manifest that **Dependabot supports** but
had **no `package-ecosystem` entry**, so their demo dependencies were never kept
up to date:

| Example | Manifest | Added ecosystem |
|---|---|---|
| `examples/php` | `composer.json` | `composer` |
| `examples/dotnet` | `*.csproj` | `nuget` |
| `examples/java` | `pom.xml` | `maven` |
| `examples/dart` | `pubspec.yaml` | `pub` |
| `examples/swift` | `Package.swift` | `swift` |

Each new block mirrors the existing example policy: **weekly**, grouped (`*`),
**major-version bumps ignored**, `open-pull-requests-limit: 10`.

## Intentionally not covered

Languages whose manifest Dependabot has **no ecosystem** for — crystal (shards),
haskell (cabal), julia (Pkg), ocaml (opam) — and deno/zig (no Dependabot-trackable
manifest in the example) get no entry. This is a Dependabot limitation, not an
omission.

## Prevent future drift

The php/dotnet/java/dart/swift gaps appeared because the **"Adding a New Language"**
checklist in `CLAUDE.md` never mentioned `dependabot.yml`. Added a step there to
decide Dependabot coverage per language (with the manifest→ecosystem mapping and the
list of unsupported languages), so the next language addition handles it explicitly.

## Verification

- `dependabot.yml` parses; ecosystems now: pip, npm, bundler, gomod, cargo,
  **composer, nuget, maven, pub, swift**, github-actions (6 → 11).
- pre-commit (check-yaml, markdownlint) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)