### PR TITLE
:construction_worker: Add workflow_dispatch to the Dependabot auto-rebase workflow

### DIFF
--- a/.github/workflows/dependabot-auto-rebase.yml
+++ b/.github/workflows/dependabot-auto-rebase.yml
@@ -36,6 +36,9 @@ on:
   push:
     branches:
       - main
+  # Manual "rebase every open Dependabot PR now" button — handy after main
+  # changes without a Dependabot merge, or to retry if a rebase was missed.
+  workflow_dispatch:
 
 # If several commits land on main in quick succession, rebase once for the
 # latest state instead of stacking duplicate requests.


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to `dependabot-auto-rebase.yml` so the
"rebase every open Dependabot PR" job can be run **on demand**, not only on push
to `main`. Job logic is unchanged.

Useful after the GitHub App credentials were just configured (to verify/kick off
rebasing without waiting for the next merge), or to retry if a rebase was missed.

## Verification

- pre-commit (actionlint, check-yaml) pass.
- Merging this also serves as the first real run with the App secrets present and
  an open Dependabot PR (#559) as a live target — the previously-skipped
  "Mint a short-lived GitHub App token" / "Ask Dependabot to rebase" steps should
  now execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)