### PR TITLE
:green_heart: Fix Dependabot PR detection in the auto-rebase workflow

### DIFF
--- a/.github/workflows/dependabot-auto-rebase.yml
+++ b/.github/workflows/dependabot-auto-rebase.yml
@@ -82,14 +82,16 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          # Collect every open PR opened by Dependabot. Filtering on the author
-          # login (rather than --author) keeps this robust regardless of how the
-          # bot account is referenced.
+          # Collect every open PR opened by Dependabot by its branch prefix.
+          # Dependabot always names its branches "dependabot/<ecosystem>/...",
+          # which is stable across gh versions — unlike the author login, which
+          # gh reports as "app/dependabot" (>= 2.x), not "dependabot[bot]", so an
+          # exact author-login match silently finds nothing.
           mapfile -t prs < <(
             gh pr list \
               --state open \
-              --json number,author \
-              --jq '.[] | select(.author.login == "dependabot[bot]") | .number'
+              --json number,headRefName \
+              --jq '.[] | select(.headRefName | startswith("dependabot/")) | .number'
           )
 
           if [ "${#prs[@]}" -eq 0 ]; then


### PR DESCRIPTION
## Summary

The auto-rebase workflow never actually rebased anything: it selected PRs with
`.author.login == "dependabot[bot]"`, but `gh` (>= 2.x; runner has 2.93.0) reports
the Dependabot author login as **`app/dependabot`**. The exact-string match found
nothing, so the job logged **"No open Dependabot PRs to rebase"** and exited — even
with an open Dependabot PR (#559) and the newly-configured GitHub App credentials
working (token minted successfully).

## Fix

Select Dependabot PRs by **branch prefix** instead: Dependabot always names its
branches `dependabot/<ecosystem>/...`, which is stable across `gh` versions
(unlike the author login).

```diff
-  --json number,author \
-  --jq '.[] | select(.author.login == "dependabot[bot]") | .number'
+  --json number,headRefName \
+  --jq '.[] | select(.headRefName | startswith("dependabot/")) | .number'
```

## Verification plan

After merge, run the workflow via its `workflow_dispatch` trigger (added in #560)
with #559 still open — the "Ask Dependabot to rebase" step should now find #559 and
post `@dependabot rebase` (instead of "No open Dependabot PRs").

CI-only fix (`:green_heart:`); no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)