### PR TITLE
:green_heart: Auto-rebase: post the rebase comment via REST (fine-grained PAT compat)

### DIFF
--- a/.github/workflows/dependabot-auto-rebase.yml
+++ b/.github/workflows/dependabot-auto-rebase.yml
@@ -87,5 +87,11 @@ jobs:
 
           for pr in "${prs[@]}"; do
             echo "Requesting rebase for PR #${pr}"
-            gh pr comment "${pr}" --body "@dependabot rebase"
+            # Post via the REST issue-comments endpoint, NOT `gh pr comment`:
+            # `gh pr comment` uses the GraphQL `addComment` mutation, which a
+            # fine-grained PAT cannot call ("Resource not accessible by personal
+            # access token"), even with Pull requests / Issues = write. The REST
+            # endpoint works with a fine-grained PAT that has Issues: write.
+            gh api --method POST "repos/${GH_REPO}/issues/${pr}/comments" \
+              -f "body=@dependabot rebase"
           done


### PR DESCRIPTION
## Summary

The PAT-based comment failed with `GraphQL: Resource not accessible by personal
access token (addComment)`, even though `PAT_FOR_PUSHES` has Pull requests / Issues
= Read and write. Cause: `gh pr comment` uses the GraphQL `addComment` mutation,
which **fine-grained PATs cannot call** (GraphQL queries like `gh pr list` work, but
that write mutation is blocked).

## Fix

Post the comment via the **REST** issue-comments endpoint, which a fine-grained PAT
with `Issues: write` can use:

```diff
-  gh pr comment "${pr}" --body "@dependabot rebase"
+  gh api --method POST "repos/${GH_REPO}/issues/${pr}/comments" -f "body=@dependabot rebase"
```

(Works with both classic `repo`-scope and fine-grained PATs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)