### PR TITLE
:memo: docs: list all 18 languages in the Available Outputs table

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -271,15 +271,28 @@ test_matrix:
 
 The action provides the following outputs:
 
-| Output            | Description                |
-|-------------------|----------------------------|
-| `os`              | List of operating systems  |
-| `versions_python` | List of Python versions    |
-| `versions_ruby`   | List of Ruby versions      |
-| `versions_nodejs` | List of Node.js versions   |
-| `versions_go`     | List of Go versions        |
-| `versions_rust`   | List of Rust versions      |
-| `ghpages_branch`  | GitHub Pages branch name   |
+| Output             | Description                |
+|--------------------|----------------------------|
+| `os`               | List of operating systems  |
+| `versions_python`  | List of Python versions    |
+| `versions_ruby`    | List of Ruby versions      |
+| `versions_nodejs`  | List of Node.js versions   |
+| `versions_go`      | List of Go versions        |
+| `versions_rust`    | List of Rust versions      |
+| `versions_php`     | List of PHP versions       |
+| `versions_dotnet`  | List of .NET (C#) versions |
+| `versions_java`    | List of Java versions      |
+| `versions_deno`    | List of Deno versions      |
+| `versions_bun`     | List of Bun versions       |
+| `versions_zig`     | List of Zig versions       |
+| `versions_elixir`  | List of Elixir versions    |
+| `versions_dart`    | List of Dart versions      |
+| `versions_swift`   | List of Swift versions     |
+| `versions_julia`   | List of Julia versions     |
+| `versions_crystal` | List of Crystal versions   |
+| `versions_haskell` | List of Haskell versions   |
+| `versions_ocaml`   | List of OCaml versions     |
+| `ghpages_branch`   | GitHub Pages branch name   |
 
 !!! tip "How to refer to Output in subsequent steps or jobs"
 


### PR DESCRIPTION
## Summary

Follow-up to the language-coverage docs: the **Available Outputs** table in *Getting Started* only listed the original five languages (python/ruby/nodejs/go/rust). It now lists **every output the action exposes** per `action.yml` (adds php, dotnet, java, deno, bun, zig, elixir, dart, swift, julia, crystal, haskell, ocaml).

## Audit of similar spots
Checked the other places that enumerate languages/outputs — all already complete, no change needed:
- README → *Supported Matrix Components* (18 rows)
- `docs/reference/options.md` → strategy inputs + output variables (18 each)
- `docs/features/dynamic-update.md` → strategy table + version-sources list (18 each)

## Verification
- markdownlint + sync-doc-action-refs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)