### PR TITLE
:lock: ci: add Dependabot PR merge-safety gate (dependency-review, metadata, cooldown)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,28 @@ version: 2
 #   test matrix covers (e.g. parallel 1.x -> 2.1.0 requiring Ruby >= 3.3; see
 #   issues #482 / #484). Bump example majors intentionally alongside a matrix
 #   review instead of automatically.
+#
+# Merge-safety gate (a green test run is necessary but NOT sufficient):
+# - `cooldown` (below) delays every bump until the release has been public for a
+#   few days, so a freshly-published / compromised version is not pulled instantly.
+# - `dependency-review.yml` fails any PR that introduces a vulnerable dependency.
+# - `dependabot-metadata.yml` labels each PR by semver bump so the risk is obvious.
+# - Merging stays MANUAL (auto-merge is disabled); `dependabot-auto-rebase.yml` only
+#   rebases open PRs so they stay mergeable, it never merges them.
 updates:
   # Python dependencies (shipped package)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -27,6 +43,14 @@ updates:
     directory: "/examples/nodejs"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -41,6 +65,14 @@ updates:
     directory: "/examples/ruby"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -55,6 +87,14 @@ updates:
     directory: "/examples/go"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -69,6 +109,14 @@ updates:
     directory: "/examples/rust"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -83,6 +131,14 @@ updates:
     directory: "/examples/php"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -97,6 +153,14 @@ updates:
     directory: "/examples/dotnet"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -111,6 +175,14 @@ updates:
     directory: "/examples/java"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -125,6 +197,14 @@ updates:
     directory: "/examples/dart"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -139,6 +219,14 @@ updates:
     directory: "/examples/swift"
     schedule:
       interval: "weekly"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:
@@ -153,6 +241,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Wait until a release has been public for a few days before proposing it,
+    # so a freshly-published (possibly compromised) version is not pulled the
+    # instant it ships. Longer window for higher-impact bumps.
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dependencies:
         patterns:

--- a/.github/workflows/dependabot-metadata.yml
+++ b/.github/workflows/dependabot-metadata.yml
@@ -1,0 +1,65 @@
+name: Dependabot Metadata
+
+# Why this exists (part of the Dependabot-PR safety gate):
+# To judge a Dependabot PR at a glance, label it by the semver bump type so a
+# reviewer immediately sees the risk: patch/minor bumps are routine, a major bump
+# can change behaviour or raise a runtime requirement and warrants a closer look.
+# This does NOT auto-merge anything - it only annotates, so the human merge
+# decision is better informed (see also dependency-review.yml + the `cooldown`
+# in dependabot.yml).
+#
+# Why pull_request_target (and why it is safe here):
+# Dependabot PRs run with a read-only GITHUB_TOKEN under the normal `pull_request`
+# trigger, so they cannot add labels. `pull_request_target` runs in the context of
+# the base repo with a writable token, which is required to label the PR. It is
+# safe because this job NEVER checks out or executes the PR's code - it only reads
+# Dependabot's own metadata and calls the labels API.
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    # Only act on PRs actually opened by Dependabot.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label the PR by update type
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+        run: |
+          # Ensure the labels exist (idempotent: create or update, never fail).
+          gh label create "dependencies"       --color "0366d6" --description "Dependency updates"                  --force
+          gh label create "dependency:patch"   --color "0e8a16" --description "Patch/minor bump (routine, low risk)" --force
+          gh label create "dependency:major"   --color "b60205" --description "Major bump (review carefully)"        --force
+
+          gh pr edit "${PR}" --add-label "dependencies"
+
+          case "${UPDATE_TYPE}" in
+            version-update:semver-patch|version-update:semver-minor)
+              echo "Patch/minor bump (${UPDATE_TYPE}) -> low risk"
+              gh pr edit "${PR}" --add-label "dependency:patch"
+              ;;
+            version-update:semver-major)
+              echo "Major bump (${UPDATE_TYPE}) -> review carefully"
+              gh pr edit "${PR}" --add-label "dependency:major"
+              ;;
+            *)
+              echo "Unknown/empty update type: '${UPDATE_TYPE}' (no risk label added)"
+              ;;
+          esac

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,40 @@
+name: Dependency Review
+
+# Why this exists (part of the Dependabot-PR safety gate):
+# A green test suite proves the code still works - it does NOT prove the
+# dependency change is safe to merge. This job inspects the *dependency diff* of
+# every PR (base..head) against the GitHub Advisory Database and fails the PR if
+# it introduces a dependency with a known vulnerability (>= moderate) or a denied
+# license. Combined with the metadata labels (dependabot-metadata.yml) and the
+# Dependabot `cooldown` in dependabot.yml, this is how we judge whether a bump is
+# actually safe to merge - merging itself stays 100% manual.
+#
+# It is a no-op on PRs that change no manifest/lockfile (e.g. docs-only PRs), so
+# it is cheap to run on everything. Public repo => the dependency graph and
+# review API are available at no cost.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  # Needed only so the action can post its summary comment on a failing PR.
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # Fail the PR on a newly introduced vulnerability of moderate severity
+          # or higher. Lower to 'low' to be stricter, raise to 'high' to be laxer.
+          fail-on-severity: moderate
+          # Post a readable summary into the PR only when the check fails.
+          comment-summary-in-pr: on-failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,27 @@ All `uses:` actions in `.github/workflows/**` and `action.yml` are pinned to com
 SHAs (with the version tag as a trailing comment) — except the self-reference
 `uses: 7rikazhexde/json2vars-setter@vX.Y.Z`, which the Versioning Rule keeps as a tag.
 
+### Dependabot PR safety gate
+
+A passing test run shows the code still works; it does **not** prove a dependency bump
+is safe to merge. Four layers decide that, and **merging always stays manual** (repo
+auto-merge is disabled):
+
+1. **`cooldown`** (in `.github/dependabot.yml`) delays every bump until the release has
+   been public for a few days (longer for major), so a freshly-published / compromised
+   version is not pulled the instant it ships.
+2. **`dependency-review.yml`** (on every PR to `main`) fails the PR if the dependency diff
+   introduces a vulnerability ≥ moderate (GitHub Advisory DB). No-op on PRs with no
+   manifest change, so it is cheap to run on everything.
+3. **`dependabot-metadata.yml`** (`pull_request_target`, Dependabot PRs only) labels each
+   PR by semver bump (`dependency:patch` vs `dependency:major`) so the risk is obvious at a
+   glance. It only labels — it never checks out the PR's code, and never merges.
+4. **`dependabot-auto-rebase.yml`** only *rebases* open Dependabot PRs so they stay
+   mergeable (see [[dependabot-auto-rebase-setup]] in memory); a human still clicks Merge.
+
+`dependency-review` should be a **required** status check in branch protection so the gate
+cannot be skipped (branch protection is configured in the repo settings, not in-repo).
+
 ## Architecture
 
 ### Three Feature Modules (`json2vars_setter/features/`)


### PR DESCRIPTION
## Summary

Requirement ③ — a green test run alone is **not** a safe basis for merging a Dependabot PR. This adds a four-layer merge-safety gate. **Merging stays 100% manual** (repo auto-merge is disabled; the existing auto-rebase workflow only rebases, never merges).

| Layer | File | What it does |
|-------|------|--------------|
| **Cooldown** | `.github/dependabot.yml` | Delays every bump until the release has been public a few days (3 patch / 7 minor / 14 major), so a freshly-published / compromised version isn't pulled instantly. Added to all 11 ecosystems. |
| **Dependency review** | `dependency-review.yml` | On every PR to `main`, fails the PR if its dependency diff introduces a vulnerability ≥ moderate (GitHub Advisory DB). No-op on PRs with no manifest change. |
| **Metadata labels** | `dependabot-metadata.yml` | Labels Dependabot PRs by semver bump (`dependency:patch` / `dependency:major`) so risk is obvious. `pull_request_target`, Dependabot-only; **never checks out the PR's code**, only labels. |
| **Manual merge** | (policy) | Documented in dependabot.yml + CLAUDE.md. |

## Follow-up (owner, repo settings)
Make **`dependency-review`** a *required* status check in branch protection so the gate can't be skipped (branch protection lives in settings, not in-repo).

## Verification
- YAML valid; pre-commit clean (actionlint, markdownlint, yaml, typos, sync-doc-action-refs).
- Actions SHA-pinned with version comments (`dependency-review-action@v5.0.0`, `fetch-metadata@v3.1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)