### PR TITLE
:recycle: refactor: make the action's output log proportional to the matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,10 @@ or the addition is incomplete:
    `--<lang>` argument, the `args.<lang> = args.all` line in the `--all` block, and
    the `if args.<lang>: language_strategies["<lang>"] = ...` wiring.
 4. **Action contract** — `action.yml`: add the `<lang>-strategy` input, the
-   `versions_<lang>` output, the strategy-arg building block, and the summary `echo`.
+   `versions_<lang>` output, and the strategy-arg building block. **No per-language
+   summary `echo` is needed**: `features/github_output.py` (`print_output_summary`)
+   logs a matrix-proportional summary of only the keys present in the JSON, so the
+   action's output log scales with the matrix, not the language set.
 5. **Tests (keep 100% coverage)** — `tests/version/fetchers/test_<lang>.py`, plus add
    the language to `tests/version/test_registry.py` and the `--all` / individual-flag
    assertions in `tests/features/test_matrix_update.py`. The version-cache tests are

--- a/action.yml
+++ b/action.yml
@@ -422,30 +422,3 @@ runs:
         uv run --no-sync python -m json2vars_setter.features.github_output "${JSON_ABSOLUTE_PATH}"
       env:
         GITHUB_OUTPUT: $GITHUB_OUTPUT
-
-    # Output debug information
-    - name: Debug Output Values
-      shell: bash
-      run: |
-        echo "Debug: Checking output values"
-        echo "OS: ${{ steps.set_outputs.outputs.os }}"
-        echo "Python Versions: ${{ steps.set_outputs.outputs.versions_python }}"
-        echo "Ruby Versions: ${{ steps.set_outputs.outputs.versions_ruby }}"
-        echo "Node.js Versions: ${{ steps.set_outputs.outputs.versions_nodejs }}"
-        echo "Go Versions: ${{ steps.set_outputs.outputs.versions_go }}"
-        echo "Rust Versions: ${{ steps.set_outputs.outputs.versions_rust }}"
-        echo "PHP Versions: ${{ steps.set_outputs.outputs.versions_php }}"
-        echo ".NET Versions: ${{ steps.set_outputs.outputs.versions_dotnet }}"
-        echo "Java Versions: ${{ steps.set_outputs.outputs.versions_java }}"
-        echo "Deno Versions: ${{ steps.set_outputs.outputs.versions_deno }}"
-        echo "Bun Versions: ${{ steps.set_outputs.outputs.versions_bun }}"
-        echo "Zig Versions: ${{ steps.set_outputs.outputs.versions_zig }}"
-        echo "Elixir Versions: ${{ steps.set_outputs.outputs.versions_elixir }}"
-        echo "Dart Versions: ${{ steps.set_outputs.outputs.versions_dart }}"
-        echo "Swift Versions: ${{ steps.set_outputs.outputs.versions_swift }}"
-        echo "Julia Versions: ${{ steps.set_outputs.outputs.versions_julia }}"
-        echo "Crystal Versions: ${{ steps.set_outputs.outputs.versions_crystal }}"
-        echo "Haskell Versions: ${{ steps.set_outputs.outputs.versions_haskell }}"
-        echo "OCaml Versions: ${{ steps.set_outputs.outputs.versions_ocaml }}"
-        echo "Kotlin Versions: ${{ steps.set_outputs.outputs.versions_kotlin }}"
-        echo "GitHub Pages Branch: ${{ steps.set_outputs.outputs.ghpages_branch }}"

--- a/json2vars_setter/features/github_output.py
+++ b/json2vars_setter/features/github_output.py
@@ -71,6 +71,31 @@ def parse_json(data: object, prefix: str = "", debug: bool = False) -> Dict[str,
     return outputs
 
 
+def print_output_summary(data: object) -> None:
+    """Print a concise, matrix-proportional summary of the parsed outputs.
+
+    Only the keys actually present in the JSON are shown. For a matrix that lists
+    Python and Node.js, just those (plus ``os`` / ``ghpages_branch``) are printed,
+    rather than every supported language — so the log stays proportional to the
+    matrix as the set of supported languages grows.
+
+    Args:
+        data: The original JSON data (before flattening).
+    """
+    if not isinstance(data, dict):
+        return
+
+    print("Outputs summary:")
+    for key, value in data.items():
+        if key == "versions" and isinstance(value, dict):
+            for language, versions in value.items():
+                print(f"  {language} versions: {json.dumps(versions)}")
+        elif isinstance(value, (list, dict)):
+            print(f"  {key}: {json.dumps(value)}")
+        else:
+            print(f"  {key}: {value}")
+
+
 def main(argv: Optional[List[str]] = None) -> None:
     """Read a JSON file and write its contents to GITHUB_OUTPUT.
 
@@ -91,6 +116,10 @@ def main(argv: Optional[List[str]] = None) -> None:
     # Parse the JSON data and write to GITHUB_OUTPUT
     collected_outputs = parse_json(data, debug=debug)
     set_github_output(collected_outputs, debug=debug)
+
+    # Print a concise summary that scales with the matrix (only the keys present
+    # in the JSON), replacing the former static per-language debug echo block.
+    print_output_summary(data)
 
 
 if __name__ == "__main__":

--- a/tests/features/test_github_output.py
+++ b/tests/features/test_github_output.py
@@ -8,7 +8,12 @@ from typing import Dict
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from json2vars_setter.features.github_output import parse_json, set_github_output
+from json2vars_setter.features.github_output import (
+    main,
+    parse_json,
+    print_output_summary,
+    set_github_output,
+)
 from json2vars_setter.version.core.utils import JsonObject
 
 MATRIX_JSON_PATH = "./tests/matrix_static.json"
@@ -116,6 +121,55 @@ def test_parse_json_scalar_list_with_debug(capsys: pytest.CaptureFixture[str]) -
     assert "Debug: Parsed list '' value='[\"a\", \"b\"]'" in captured.out
     assert "Debug: Parsed list item '0' value='a'" in captured.out
     assert "Debug: Parsed list item '1' value='b'" in captured.out
+
+
+# --- Test case for print_output_summary() ---
+
+
+def test_print_output_summary_is_matrix_proportional(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The summary lists only the languages present in the matrix, not all of them."""
+    data = {
+        "os": ["ubuntu-latest", "macos-latest"],
+        "versions": {"python": ["3.13"], "nodejs": ["20"]},
+        "ghpages_branch": "gh-pages",
+    }
+    print_output_summary(data)
+
+    out = capsys.readouterr().out
+    assert "Outputs summary:" in out
+    assert '  os: ["ubuntu-latest", "macos-latest"]' in out
+    assert '  python versions: ["3.13"]' in out
+    assert '  nodejs versions: ["20"]' in out
+    assert "  ghpages_branch: gh-pages" in out
+    # Languages absent from the matrix must not appear in the log.
+    assert "ruby" not in out
+    assert "go versions" not in out
+
+
+def test_print_output_summary_ignores_non_dict(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-dict top-level payload prints nothing (no summary)."""
+    print_output_summary(["a", "b"])
+    assert capsys.readouterr().out == ""
+
+
+def test_main_prints_matrix_proportional_summary(
+    monkeypatch: MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Running main() prints the proportional summary for the matrix's languages."""
+    output_file = tmp_path / "GITHUB_OUTPUT"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    main([MATRIX_JSON_PATH])
+
+    out = capsys.readouterr().out
+    assert "Outputs summary:" in out
+    assert "python versions:" in out
+    # matrix_static.json carries no Kotlin entry, so it must not be logged.
+    assert "kotlin" not in out
 
 
 # --- Test case for set_github_output() ---


### PR DESCRIPTION
## Summary

`action.yml`'s **"Debug Output Values"** step echoed **every supported language
unconditionally**. A matrix that only uses Python and Node.js still printed ~17 empty
`<Lang> Versions:` lines, and the noise grew with every language added. That block was
also a **hardcoded language list** — exactly what the registry-as-single-source rule
warns against — so each new language had to add a line to it.

This replaces it with a **data-driven** summary that scales with the matrix, not with
the set of supported languages.

## Changes

- **`json2vars_setter/features/github_output.py`** — add `print_output_summary()`,
  which walks the original JSON and logs only the keys actually present (`os`, the
  languages under `versions`, `ghpages_branch`, …); called from `main()` after writing
  `GITHUB_OUTPUT`.
- **`action.yml`** — remove the static per-language "Debug Output Values" step.
- **`tests/features/test_github_output.py`** — cover the proportional summary, the
  non-dict no-op, and the `main()` summary path (**100% coverage kept**).
- **`CLAUDE.md`** — drop the "summary `echo`" item from the Adding-a-New-Language
  action-contract step (now data-driven, so a new language needs no `action.yml` log change).

## Example

For a matrix with only Python + Node.js, the log goes from ~21 lines (17 empty) to:

```
Outputs summary:
  os: ["ubuntu-latest", "macos-latest"]
  python versions: ["3.13"]
  nodejs versions: ["20"]
  ghpages_branch: gh-pages
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)