### PR TITLE
:wrench: ci: pin clang/gcc/flutter test workflows to @v1.12.0

### DIFF
--- a/.github/workflows/clang_test.yml
+++ b/.github/workflows/clang_test.yml
@@ -32,11 +32,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Two-phase reference (see CLAUDE.md): the `versions_clang` output does
-        # not exist in the published tag until the release that adds Clang, so
-        # this introducing PR points at the in-repo action. Swap to
-        # 7rikazhexde/json2vars-setter@vX.Y.Z after that release.
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.12.0
         with:
           json-file: examples/clang/clang_project_matrix.json
 

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -32,11 +32,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Two-phase reference (see CLAUDE.md): the `versions_flutter` output does
-        # not exist in the published tag until the release that adds Flutter, so
-        # this introducing PR points at the in-repo action. Swap to
-        # 7rikazhexde/json2vars-setter@vX.Y.Z after that release.
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.12.0
         with:
           json-file: examples/flutter/flutter_project_matrix.json
 

--- a/.github/workflows/gcc_test.yml
+++ b/.github/workflows/gcc_test.yml
@@ -32,11 +32,7 @@ jobs:
 
       - name: Set variables from JSON
         id: json2vars
-        # Two-phase reference (see CLAUDE.md): the `versions_gcc` output does not
-        # exist in the published tag until the release that adds GCC, so this
-        # introducing PR points at the in-repo action. Swap to
-        # 7rikazhexde/json2vars-setter@vX.Y.Z after that release.
-        uses: ./
+        uses: 7rikazhexde/json2vars-setter@v1.12.0
         with:
           json-file: examples/gcc/gcc_project_matrix.json
 


### PR DESCRIPTION
## Summary

Completes the **two-phase reference swap** for the three C++/Flutter example workflows
now that **v1.12.0** ships their outputs (`versions_clang`, `versions_gcc`,
`versions_flutter`).

`clang_test.yml`, `gcc_test.yml` and `flutter_test.yml` were introduced pointing at the
in-repo action (`uses: ./`) because their outputs did not exist in the published tag yet.
With v1.12.0 released, they switch to the pinned tag
`uses: 7rikazhexde/json2vars-setter@v1.12.0`, matching every other `*_test.yml` and the
Versioning Rule. From here `sync-version-refs.sh` keeps them current on each release.

This PR edits the three workflow files, so each runs once here against `@v1.12.0` to
confirm the swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)