### PR TITLE
Fix invalid dependabot.yml: drop unsupported semver-*-days cooldown for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -342,12 +342,11 @@ updates:
       interval: "daily"
     # Wait until a release has been public for a few days before proposing it,
     # so a freshly-published (possibly compromised) version is not pulled the
-    # instant it ships. Longer window for higher-impact bumps.
+    # instant it ships. NOTE: the github-actions ecosystem does NOT support the
+    # semver-*-days granularity (Dependabot rejects them here), so only the flat
+    # default-days window applies.
     cooldown:
       default-days: 5
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
## Summary

The merge of #584 surfaced a pre-existing `.github/dependabot.yml` validation failure (the **`.github/dependabot.yml`** check on the merge commit):

```
The property '#/updates/11/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/11/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/11/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

The `github-actions` ecosystem only supports the flat `cooldown.default-days` window — not the `semver-*-days` granularity. These keys predate #584 (they exist as far back as v1.12.1); they were only re-validated now because #584 was the first change to touch `dependabot.yml`. An invalid config means Dependabot stops processing the file, so this should be fixed promptly.

## Change

- `github-actions` block: keep `cooldown.default-days: 5`, drop the three `semver-*-days` keys, and add a note explaining the ecosystem limitation.
- The **11 other ecosystems keep** their `semver-*-days` granularity (the validator accepts them there — only `github-actions` was flagged).

## Verification

- `dependabot.yml` parses; the `github-actions` cooldown is now `{default-days: 5}` and the `commit-message.prefix` added in #584 is preserved.
- pre-commit (actionlint / yamllint / check-yaml) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)