### PR TITLE
Document mlugg/setup-zig move to Codeberg (informational, no functional change)

### DIFF
--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -64,6 +64,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Zig
+        # mlugg/setup-zig moved its main repository to Codeberg
+        # (https://codeberg.org/mlugg/setup-zig). This GitHub repo is now an
+        # auto-synced MIRROR (issues/PRs not accepted there), but the maintainer
+        # explicitly commits to keep supporting GitHub Actions, so this
+        # `uses: mlugg/setup-zig@<sha>` reference and Dependabot tracking keep
+        # working unchanged. NOTE: this is unrelated to the Zig *version fetcher*,
+        # which reads the separate ziglang/zig compiler repo (still on GitHub).
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: ${{ matrix.zig-version }}

--- a/docs/reference/version-sources.md
+++ b/docs/reference/version-sources.md
@@ -184,6 +184,13 @@ source the fetcher reads (see the Swift caveat below).
   `X.Y.Z-dev.*` nightly builds are excluded); Zig is still pre-1.0, so `stable` is
   the previous **minor** (second component) of `latest`. Example matrices use the
   exact form (`"0.14.1"`, `"0.15.2"`) that `mlugg/setup-zig` accepts.
+- **Setup action note:** `mlugg/setup-zig` has moved its main repository to
+  [Codeberg](https://codeberg.org/mlugg/setup-zig). The version fetcher is
+  **unaffected** — it reads the `ziglang/zig` *compiler* repo (still on GitHub),
+  which is a different project from the *setup action*. The `mlugg/setup-zig`
+  GitHub repo used by `zig_test.yml` is now an auto-synced mirror; the maintainer
+  commits to keep supporting GitHub Actions, so the pinned `uses:` reference and
+  Dependabot tracking continue to work.
 
 ### Elixir — `elixir-lang/elixir`
 


### PR DESCRIPTION
## Summary

`mlugg/setup-zig` has moved its main repository to [Codeberg](https://codeberg.org/mlugg/setup-zig). No functional change is needed — this PR only records the situation so future maintainers understand it.

### Findings (why no code change)

- The GitHub `mlugg/setup-zig` repo is now an **auto-synced mirror** (issues/PRs not accepted there), but its README explicitly states *"setup-zig will continue to support GitHub Actions into the future — that isn't changing."*
- Releases still flow to the GitHub mirror (latest `v2.2.1`, 2026-01-19); our pin `mlugg/setup-zig@d1434d0 # v2.2.1` is already the latest, and Dependabot keeps tracking the mirror's tags.
- The Zig **version fetcher** is unrelated: it reads the `ziglang/zig` *compiler* repo (still on GitHub, active), not the setup action — so fetching is unaffected.

### Changes (notes only)

- `.github/workflows/zig_test.yml`: comment at the `Set up Zig` step.
- `docs/reference/version-sources.md` (Zig section): matching note, clarifying the fetcher vs. setup-action distinction.

## Verification

- `zig_test.yml` parses; pre-commit (actionlint / markdownlint / yamllint) passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)