### PR TITLE
:memo: docs(pyproject): note uv/hatchling toolchain & force dependency-graph rescan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
 json2vars = "json2vars_setter.cli:app"
 
 [build-system]
+# Dependency management is uv (uv.lock); the build backend is hatchling. The
+# project migrated off Poetry in 5157d99, so there is intentionally no
+# [tool.poetry] table and no poetry.lock.
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
## Summary

After the Poetry → uv migration (`poetry.lock` removed in 5157d99), GitHub's
dependency graph kept stale entries for the old `poetry.lock`
(`poetry`, `poetry-core`, `msgpack@1.1.0`). When the msgpack out-of-bounds-read
advisory was published, Dependabot matched it against that orphaned manifest and
opened security alert **#57** referencing a `poetry.lock` that no longer exists.

The file is fully gone (not on disk, not tracked). Because this repository is
**public**, the dependency graph cannot be toggled off in Settings, so the only
way to purge the orphaned manifest is to push a change to a Python manifest and
let GitHub re-scan the dependency graph for the default branch.

## Change

Add a short `[build-system]` comment documenting that dependency management is
uv (`uv.lock`) with a hatchling backend, and that there is intentionally no
`[tool.poetry]` table or `poetry.lock`. This has documentary value **and** edits
the Python manifest, which triggers the dependency-graph re-scan on merge.

## Expected effect

On merge to `main`, GitHub rebuilds the dependency graph from the current tree,
drops the stale `poetry.lock` manifest, and Dependabot alert #57 auto-resolves
(the underlying `poetry.lock`/msgpack entry no longer exists). No `.github/dependabot.yml`
change is involved — that file controls version-update PRs, not security alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)