### PR TITLE
:bug: Fix Elixir test workflow failing on windows-latest (setup-beam ImageOS win25-vs2026)

### DIFF
--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -63,6 +63,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Normalize ImageOS for setup-beam on Windows
+        # GitHub's windows-latest image now reports ImageOS=win25-vs2026, but
+        # erlef/setup-beam v1.24.0 only maps the bare 'win25' label and aborts on
+        # the variant suffix (runner-images#14004; fix pending in setup-beam#461).
+        # Strip the suffix (win25-vs2026 -> win25) so the OS lookup succeeds; this
+        # is future-proof for later variants and a no-op for un-suffixed labels.
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "ImageOS=${ImageOS%%-*}" >> "$GITHUB_ENV"
+
       - name: Set up Erlang/Elixir
         # erlef/setup-beam requires an OTP version; OTP 27 is compatible with
         # every Elixir version in the matrix (1.18 supports OTP 25-27, 1.19


### PR DESCRIPTION
## Problem

The **Elixir Test** workflow fails on `windows-latest` for every Elixir version (e.g. PR #589, jobs `run_tests (windows-latest, 1.18)` / `(windows-latest, 1.19)`):

```
##[error]Tried to map a target OS from env. variable 'ImageOS' (got win25-vs2026), but failed.
... one of the following: ['ubuntu22','ubuntu24','win19','win22','win25','macos13',...]
```

GitHub'\''s `windows-latest` runner image is now `windows-2025-vs2026`, which reports `ImageOS=win25-vs2026`. `erlef/setup-beam@v1.24.0` (the latest release) only maps the bare `win25` label and aborts on the variant suffix. This is a known runner-image change (actions/runner-images#14004); the upstream fix is still pending in erlef/setup-beam#461, so it cannot be resolved by bumping the pinned tag.

## Fix

Add a Windows-only step before `setup-beam` that strips the variant suffix from `ImageOS` (`win25-vs2026` -> `win25`) using `${ImageOS%%-*}`:

- mirrors the upstream fix logic, so it keeps working when the image later becomes `win26-*`;
- a no-op for un-suffixed labels (`win22` stays `win22`);
- scoped to `runner.os == 'Windows'`, so Ubuntu/macOS `ImageOS` is untouched.

## Scope / similar issues

`setup-beam` is the only action in this repo that reads `ImageOS` (`grep` confirms it is used solely by `elixir_test.yml`). All other language workflows passed their Windows legs on PR #589, so no other workflow is affected.

After this merges, rebasing #589 (`@dependabot rebase`) will make its Elixir checks green.