### PR TITLE
:construction_worker: Add Merge Gate so CI failure blocks squash-merge (incl. per-language tests)

### DIFF
--- a/.github/workflows/merge_gate.yml
+++ b/.github/workflows/merge_gate.yml
@@ -1,0 +1,157 @@
+name: Merge Gate
+
+# Single required status check that aggregates every per-language / sample /
+# core test workflow that actually ran on a PR, so a red leg (e.g. the Elixir
+# Windows failure) blocks squash-merge even when the Python core gate is green.
+#
+# Why an aggregator (not "require each *_test.yml" directly): the per-language
+# workflows are paths-filtered, so a PR that doesn't touch a language never runs
+# its workflow. A directly-required check that never runs would deadlock the PR
+# ("Expected - Waiting for status"). This gate instead reports the *combined*
+# result of whatever ran, as one commit status named "Merge Gate" -- set that,
+# and only that, as the required status check in branch protection.
+#
+# How it fires: workflow_run (completed) for each blocking workflow re-evaluates
+# the PR head SHA. The always-on core workflows (prch / dependabot_prch) run on
+# every PR, so the gate always fires at least once -> no deadlock. The last
+# blocking workflow to finish produces the authoritative success/failure.
+
+on:
+  workflow_run:
+    # KEEP IN SYNC: every *blocking* workflow must be listed here so the gate
+    # re-fires when it completes. Adding a language -> add its "<Lang> Test"
+    # here (the aggregation below is path-based and needs no edit). Non-blocking
+    # workflows (Modern Quality, Dependency Review, Cleanup Caches, ...) are
+    # intentionally absent.
+    workflows:
+      # core (always run on every PR)
+      - "Test on PR by matrix.json (Except Dependabot)"
+      - "Dependabot PR Check"
+      # per-language tests
+      - "Bun Test"
+      - "Clang Test"
+      - "Crystal Test"
+      - "Dart Test"
+      - "Deno Test"
+      - ".NET Test"
+      - "Elixir Test"
+      - "Flutter Test"
+      - "GCC Test"
+      - "Go Test"
+      - "Haskell Test"
+      - "Java Test"
+      - "Julia Test"
+      - "Kotlin Test"
+      - "Node.js Test"
+      - "OCaml Test"
+      - "PHP Test"
+      - "Python Test"
+      - "Ruby Test"
+      - "Rust Test"
+      - "Swift Test"
+      - "Zig Test"
+      # sample (use-case) workflows
+      - "Sample - Conditional Matrix (PR vs full)"
+      - "Sample - Dynamic Update (scheduled maintenance)"
+      - "Sample - Monorepo"
+      - "Sample - Reusable Workflow (workflow_call)"
+      - "Sample - Single Source of Truth"
+      - "Sample - Template from Cache"
+      - "Sample - Version Cache (fewer API calls)"
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  statuses: write
+
+# Evaluate one gate run at a time per commit; the newest evaluation wins (each
+# run recomputes the full state from scratch, so cancelling a stale one is safe).
+concurrency:
+  group: merge-gate-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    # Only PR-triggered runs have a PR to gate; skip schedule/dispatch runs of
+    # the sample workflows.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Aggregate test workflow results into the "Merge Gate" status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+
+            // Aggregation is path-based and self-maintaining: every *_test.yml,
+            // every sample_*.yml (except the workflow_call-only library), and the
+            // two always-on core workflows count toward the gate. A new language's
+            // <lang>_test.yml is therefore included automatically.
+            const watchedPath = /^\.github\/workflows\/(.*_test\.yml|sample_.*\.yml|prch_test_matrix_json\.yml|dependabot_prch\.yml)$/;
+            const excludedPaths = new Set([
+              // workflow_call library: runs inside its caller, no standalone PR run
+              ".github/workflows/sample_reusable_lib.yml",
+            ]);
+
+            const workflows = await github.paginate(
+              github.rest.actions.listRepoWorkflows,
+              { owner, repo, per_page: 100 },
+            );
+            const watchedIds = new Set(
+              workflows
+                .filter((w) => watchedPath.test(w.path) && !excludedPaths.has(w.path))
+                .map((w) => w.id),
+            );
+
+            // All PR-triggered runs for this commit, newest first.
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              { owner, repo, head_sha: sha, event: "pull_request", per_page: 100 },
+            );
+
+            // Keep only the latest run per watched workflow.
+            const latest = new Map();
+            for (const run of runs) {
+              if (!watchedIds.has(run.workflow_id)) continue;
+              if (!latest.has(run.workflow_id)) latest.set(run.workflow_id, run);
+            }
+            const considered = [...latest.values()];
+
+            const okConclusions = new Set(["success", "skipped", "neutral"]);
+            const pending = considered.filter((r) => r.status !== "completed");
+            const failed = considered.filter(
+              (r) => r.status === "completed" && !okConclusions.has(r.conclusion),
+            );
+
+            let state, description;
+            if (failed.length > 0) {
+              // Report NG as soon as any leg fails -- preserves the failure
+              // accurately even while other legs are still running.
+              state = "failure";
+              const names = failed.map((r) => r.name).sort();
+              description = `Failing: ${names.join(", ")}`.slice(0, 140);
+            } else if (pending.length > 0) {
+              state = "pending";
+              description = `Waiting on ${pending.length} workflow(s)`;
+            } else {
+              state = "success";
+              description = `All ${considered.length} test workflow(s) passed`;
+            }
+
+            core.info(`Merge Gate for ${sha}: ${state} (${description})`);
+            core.info(
+              `considered=${considered.length} pending=${pending.length} failed=${failed.length}`,
+            );
+
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha,
+              state,
+              context: "Merge Gate",
+              description,
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,31 @@ auto-merge is disabled):
 `dependency-review` should be a **required** status check in branch protection so the gate
 cannot be skipped (branch protection is configured in the repo settings, not in-repo).
 
+### Merge Gate (CI failure blocks squash-merge)
+
+CI errors must **block merge** — including a per-language failure (e.g. the Elixir
+Windows leg) even when the Python core gate is green, because the action as a whole is
+then NG. The per-language `*_test.yml` workflows are **paths-filtered** (they only run when
+their own files change), so they **cannot** be named directly as required checks: a PR that
+doesn't touch a language would never run that workflow and would deadlock on
+"Expected — Waiting for status".
+
+`.github/workflows/merge_gate.yml` resolves this. It is a `workflow_run` **aggregator**:
+when any blocking test workflow completes on a PR, it re-queries every PR-triggered run for
+that commit SHA and writes a single commit status named **`Merge Gate`** — `failure` if any
+leg failed, `pending` while any is still running, else `success`. The always-on core
+workflows (`prch_test_matrix_json.yml` / `dependabot_prch.yml`) run on every PR, so the gate
+always fires at least once → **no deadlock**. Set **only `Merge Gate`** (plus
+`Dependency Review`) as the **required** status check in branch protection; that one check
+reflects whatever actually ran.
+
+The aggregation is **path-based / self-maintaining** (it counts every `*_test.yml`, every
+`sample_*.yml` except the `workflow_call`-only `sample_reusable_lib.yml`, and the two core
+workflows by path), so a new language is included automatically. The **one** thing to keep
+in sync is the `on.workflow_run.workflows:` trigger list in `merge_gate.yml` — a workflow
+absent from it won't re-fire the gate on its completion. **Adding a language → add its
+`"<Lang> Test"` line there** (see the Adding-a-New-Language checklist).
+
 ## Architecture
 
 ### Three Feature Modules (`json2vars_setter/features/`)
@@ -158,7 +183,10 @@ or the addition is incomplete:
    `ruby_test.yml`): `set_variables` → `run_tests` (matrix) → `update_badge`. The
    `update_badge` job needs a **dedicated gist** (`<lang>-test-badge.json`, written via
    `GIST_TOKEN`) — its `gistID` must be created by the repo owner and cannot be
-   generated programmatically.
+   generated programmatically. **Also add the new `"<Lang> Test"` to the
+   `on.workflow_run.workflows:` trigger list in `.github/workflows/merge_gate.yml`** so a
+   failure on a language-only PR blocks merge (the Merge Gate's aggregation is path-based
+   and needs no edit — only the trigger list does; see the Merge Gate section above).
 8. **Status badges** — add a row to the language table in `README.md` **and** the
    matching badge in `docs/index.md`, pointing at the new gist
    (`gist.githubusercontent.com/7rikazhexde/<GIST_ID>/raw/<lang>-test-badge.json`) and


### PR DESCRIPTION
## What

Add `.github/workflows/merge_gate.yml`, a `workflow_run` aggregator that publishes a single commit status named **`Merge Gate`**. It reflects the combined result of every per-language / sample / core test workflow that actually ran on a PR.

A failing leg (e.g. the Elixir Windows leg fixed in #590) now turns `Merge Gate` **red even when the Python core gate is green**, because the action as a whole is then failing.

## Why an aggregator (not "require each `*_test.yml`")

The per-language `*_test.yml` workflows are **paths-filtered** — they only run when their own files change. Naming them directly as required status checks would **deadlock** any PR that doesn't touch that language ("Expected — Waiting for status"). The aggregator instead reports the combined result of *whatever ran*:

- `failure` if any considered leg failed (reported as soon as a leg goes red, preserving the failure accurately),
- `pending` while any considered leg is still running,
- `success` once all considered legs passed.

The always-on core workflows (`prch_test_matrix_json.yml` / `dependabot_prch.yml`) run on **every** PR, so the gate always fires at least once → **no deadlock**, and the last leg to finish produces the authoritative result.

## Self-maintaining aggregation

Aggregation is **path-based**: every `*_test.yml`, every `sample_*.yml` (except the `workflow_call`-only `sample_reusable_lib.yml`), and the two core workflows count automatically. A new language is therefore included with no edit to the aggregation logic. The only thing to keep in sync is the `on.workflow_run.workflows:` **trigger list** (so the gate re-fires when that workflow completes) — a one-line add per new language, now part of the Adding-a-New-Language checklist.

Intentionally **excluded** from the gate: `Modern Quality (Preview)` (non-blocking by design), `Dependency Review` (its own required check), `Cleanup Caches`, and the Dependabot/maintenance workflows.

## Docs

`CLAUDE.md`: new **Merge Gate** section + a checklist item under Adding a New Language.

## Follow-up (manual, repo owner)

Enabling branch protection is what actually blocks the merge and is out of repo scope. After this merges and the gate is validated on a live PR, set **`Merge Gate`** (plus `Dependency Review`) as the **required** status check on `main`.

## Notes

- `actionlint` passes locally.
- No third-party action added beyond `actions/github-script` (already pinned/used elsewhere).