### PR TITLE
ci: make doc-sync workflows resilient to concurrent main pushes

### DIFF
--- a/.github/workflows/sync-doc-action-refs.yml
+++ b/.github/workflows/sync-doc-action-refs.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Commit and push if the docs changed
         if: steps.check.outputs.configured == 'true'
         run: |
+          msg=":memo: docs: sync action version refs in docs to workflows [skip ci]"
           if [ -z "$(git status --porcelain)" ]; then
             echo "Documentation action references already up to date; nothing to commit."
             exit 0
@@ -81,5 +82,26 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m ":memo: docs: sync action version refs in docs to workflows [skip ci]"
-          git push
+          git commit -m "${msg}"
+          # Another push-to-main workflow (notably sync-language-docs, which the same
+          # *_test.yml Dependabot bump also triggers) can land between our checkout
+          # and push and reject this one as non-fast-forward. On rejection, resync to
+          # the updated main, re-run the sync script against the now-authoritative
+          # sources, and retry -- so the result stays correct instead of failing.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); resyncing with main and re-syncing refs."
+            git fetch origin main
+            git reset --hard origin/main
+            python3 .github/scripts/sync_doc_action_refs.py
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "Documentation action references already current on the updated main; nothing to push."
+              exit 0
+            fi
+            git add -A
+            git commit -m "${msg}"
+          done
+          echo "::error::Failed to push documentation action references after multiple attempts."
+          exit 1

--- a/.github/workflows/sync-language-docs.yml
+++ b/.github/workflows/sync-language-docs.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Commit and push if the docs changed
         if: steps.check.outputs.configured == 'true'
         run: |
+          msg=":memo: docs: regenerate language pages from matrix/workflow sources [skip ci]"
           if [ -z "$(git status --porcelain)" ]; then
             echo "Language docs already up to date; nothing to commit."
             exit 0
@@ -79,5 +80,26 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m ":memo: docs: regenerate language pages from matrix/workflow sources [skip ci]"
-          git push
+          git commit -m "${msg}"
+          # Another push-to-main workflow (notably sync-doc-action-refs, which the
+          # same *_test.yml Dependabot bump also triggers) can land between our
+          # checkout and push and reject this one as non-fast-forward. On rejection,
+          # resync to the updated main, regenerate from the now-authoritative
+          # sources, and retry -- so the result stays correct instead of failing.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); resyncing with main and regenerating."
+            git fetch origin main
+            git reset --hard origin/main
+            python3 .github/scripts/gen_language_docs.py
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "Language docs already current on the updated main; nothing to push."
+              exit 0
+            fi
+            git add -A
+            git commit -m "${msg}"
+          done
+          echo "::error::Failed to push language docs after multiple attempts."
+          exit 1


### PR DESCRIPTION
## Problem

The \"Sync language docs\" workflow failed on the merged ruby/setup-ruby Dependabot bump (#596): the push to `main` was rejected with

```
! [remote rejected] main -> main (cannot lock ref 'refs/heads/main':
  is at 45ffe38 but expected daf8645)
```

### Root cause

A Dependabot bump that touches a `*_test.yml` matches the `push: main` path filter of **both** `sync-language-docs.yml` and `sync-doc-action-refs.yml`, so both fire on the same commit. Each declared its **own** `concurrency` group, so they ran in parallel, both committed a `[skip ci]` doc update, and both raced to push to `main`. The loser hit a non-fast-forward `cannot lock ref` and the workflow reported failure.

No content drift resulted here (the docs converged), but the workflow will keep failing spuriously on every future bump that touches a test workflow.

## Fix

Replace the single `git push` in each workflow's commit step with a **resync-and-retry loop**: on a non-fast-forward rejection, reset to the updated `main`, regenerate from the now-authoritative sources (the same generator/sync script), and retry — exiting cleanly if nothing remains to push. This is self-contained per workflow, so it stays correct against any other pusher to `main`, not just the sibling workflow.

A shared concurrency group was considered but rejected: it would mix the two workflows' `cancel-in-progress` semantics (a new push to one would cancel an in-progress run of the other) and would not protect against other pushers.

## Validation

- `actionlint` (incl. shellcheck of the `run` blocks) and `check-yaml` pass.
- No behavioral change in the common (no-race) path — the first `git push` still succeeds and the loop is never entered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)